### PR TITLE
Use strings for `TimeMachine.initialize()` map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Your initialization function will look like this:
 import 'package:flutter/services.dart';
 
 // TimeMachine discovers your TimeZone heuristically (it's actually pretty fast).
-await TimeMachine.initialize({rootBundle: rootBundle});
+await TimeMachine.initialize({'rootBundle': rootBundle});
 ```
 
 Once flutter gets [`Isolate.resolvePackageUri`](https://github.com/flutter/flutter/issues/14815) functionality,
@@ -156,7 +156,10 @@ Or with: https://pub.dartlang.org/packages/flutter_native_timezone
 import 'package:flutter/services.dart';
 
 // you can get Timezone information directly from the native interface with flutter_native_timezone
-await TimeMachine.initialize({rootBundle: rootBundle, timeZone: await Timezone.getLocalTimezone()});
+await TimeMachine.initialize({
+  'rootBundle': rootBundle,
+  'timeZone': await Timezone.getLocalTimezone(),
+});
 ```
 
 ### DDC Specific Notes

--- a/example/flutter_example/lib/main._dart
+++ b/example/flutter_example/lib/main._dart
@@ -22,7 +22,7 @@ Future example() async {
 
   try {
     // Sets up timezone and culture information
-    await TimeMachine.initialize({rootBundle: rootBundle});
+    await TimeMachine.initialize({'rootBundle': rootBundle});
     sb.writeln('Hello, ${DateTimeZone.local} from the Dart Time Machine!');
 
     var tzdb = await DateTimeZoneProviders.tzdb;


### PR DESCRIPTION
**Fixes: #34** (probably; see below)

When using <kbd>time_machine</kbd> with Flutter, the call to `TimeMachine.initialize()` should contain a reference to the `rootBundle`. Also, on any platform, a `timeZone` can be passed to set the local one explicitly.

The documentation and Flutter example project uses this method like the following:

```dart
TimeMachine.initialize({rootBundle: …, timeZone: …});
```

However, `vm.dart` looks for string keys (`'rootBundle'`, `'timeZone'`) — which are not found.

This seems to be the reason for #34 (line number matches), though I don't have a device with iOS to verify it.