### PR TITLE
feat: return null if dateTime eq null

### DIFF
--- a/lib/src/localdatetime.dart
+++ b/lib/src/localdatetime.dart
@@ -83,6 +83,10 @@ class LocalDateTime implements Comparable<LocalDateTime> {
   factory LocalDateTime.dateTime(DateTime dateTime, [CalendarSystem calendar]) {
     int ns;
     int days;
+    
+    if (dateTime == null) {
+      return null;
+    }
 
     if (Platform.isWeb) {
       var ms = dateTime.millisecondsSinceEpoch;


### PR DESCRIPTION
dart:core                                                                                                               Object.noSuchMethod
package:time_machine/src/localdatetime.dart 94:25                                                                       new LocalDateTime.dateTime
test/fixtures/dates.dart 56:23                                                                                          main
===== asynchronous gap ===========================
package:test_api                                                                                                        RemoteListener.start
/var/folders/yg/06n4gbh515q0_jqpnfryzjb80000gn/T/flutter_tools.GZi81P/flutter_test_listener.bi4Gcu/listener.dart 16:25  serializeSuite
/var/folders/yg/06n4gbh515q0_jqpnfryzjb80000gn/T/flutter_tools.GZi81P/flutter_test_listener.bi4Gcu/listener.dart 42:36  main

Failed to load "/Users/polrk/Documents/listta/listta-mobile-app/test/fixtures/dates.dart":
The getter 'microsecondsSinceEpoch' was called on null.
Receiver: null
Tried calling: microsecondsSinceEpoch