### PR TITLE
Fix error on LocalDateTime.dateTime with dateTime before epoch

### DIFF
--- a/lib/src/localdatetime.dart
+++ b/lib/src/localdatetime.dart
@@ -83,22 +83,25 @@ class LocalDateTime implements Comparable<LocalDateTime> {
   factory LocalDateTime.dateTime(DateTime dateTime, [CalendarSystem calendar]) {
     int ns;
     int days;
-    
+
     if (dateTime == null) {
       return null;
     }
 
     if (Platform.isWeb) {
-      var ms = dateTime.millisecondsSinceEpoch;
+      var ms = dateTime.millisecondsSinceEpoch + dateTime.timeZoneOffset.inMilliseconds;
       days = ms ~/ TimeConstants.millisecondsPerDay;
       ms -= days * TimeConstants.millisecondsPerDay;
-      ns = ms * TimeConstants.nanosecondsPerMillisecond;
-    }
-    else {
-      var us = dateTime.microsecondsSinceEpoch;
+      if (ms < 0) days--;
+      ns = TimeConstants.nanosecondsPerMillisecond *
+          (ms % TimeConstants.millisecondsPerDay);
+    } else {
+      var us = dateTime.microsecondsSinceEpoch + dateTime.timeZoneOffset.inMicroseconds;
       days = us ~/ TimeConstants.microsecondsPerDay;
       us -= days * TimeConstants.microsecondsPerDay;
-      ns = us * TimeConstants.nanosecondsPerMicrosecond;
+      if (us < 0) days--;
+      ns = TimeConstants.nanosecondsPerMicrosecond *
+          (us % TimeConstants.microsecondsPerDay);
     }
 
     return LocalDateTime.localDateAtTime(

--- a/test/localdatetime_test.dart
+++ b/test/localdatetime_test.dart
@@ -95,6 +95,16 @@ void FromDateTime()
 }
 
 @Test()
+void FromDateTimeBeforeEpoch()
+{
+  LocalDateTime expected = LocalDateTime(1966, 08, 18, 20, 53, 0);
+  // for (DateTimeKind kind in Enum.GetValues(typeof(DateTimeKind)))
+  DateTime x = DateTime.utc(1966, 08, 18, 20, 53, 0); //, kind);
+  LocalDateTime actual = LocalDateTime.dateTime(x);
+  expect(actual, expected);
+}
+
+@Test()
 void FromDateTime_WithCalendar()
 {
   // Julian calendar is 13 days behind Gregorian calendar in the 21st century


### PR DESCRIPTION
It's currently impossible to use LocalDateTime.dateTime to convert a date prior to epoch into a LocalDateTime : The ns variable contains a negative number and so the assert in LocalTime._(int nanoseconds) fails

This fixes #33