### PR TITLE
Rename @internal annotation to @isInternal

### DIFF
--- a/lib/src/ambiguous_time_error.dart
+++ b/lib/src/ambiguous_time_error.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 @immutable
 class AmbiguousTimeError extends Error {
   /// Get the local date and time which is ambiguous in the time zone.
-  @internal LocalDateTime get localDateTime => earlierMapping.localDateTime;
+  @isInternal LocalDateTime get localDateTime => earlierMapping.localDateTime;
 
   /// The time zone in which the local date and time is ambiguous.
   DateTimeZone get Zone => earlierMapping.zone;

--- a/lib/src/calendar_ordinal.dart
+++ b/lib/src/calendar_ordinal.dart
@@ -4,7 +4,7 @@
 
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 /// Enumeration of calendar ordinal values. Used for converting between a compact integer representation and a calendar system.
 /// We use 7 bits to store the calendar ordinal in YearMonthDayCalendar, so we can have up to 128 calendars.
 class CalendarOrdinal {

--- a/lib/src/calendar_system.dart
+++ b/lib/src/calendar_system.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class ICalendarSystem {
   /// Fetches a calendar system by its ordinal value, constructing it if necessary.
   static CalendarSystem forOrdinal(CalendarOrdinal ordinal) {

--- a/lib/src/calendars/badi_yearmonthday_calculator.dart
+++ b/lib/src/calendars/badi_yearmonthday_calculator.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 /// See [CalendarSystem.badi] for details about the Badíʿ calendar.
-@internal
+@isInternal
 class BadiYearMonthDayCalculator extends YearMonthDayCalculator {
 // named constants to avoid use of raw numbers in the code
   static const int _averageDaysPer10Years = 3652; // Ideally 365.2425 per year...

--- a/lib/src/calendars/coptic_yearmonthday_calculator.dart
+++ b/lib/src/calendars/coptic_yearmonthday_calculator.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 class CopticYearMonthDayCalculator extends FixedMonthYearMonthDayCalculator {
   CopticYearMonthDayCalculator()
       : super(1, 9715, -615558) {

--- a/lib/src/calendars/era_calculator.dart
+++ b/lib/src/calendars/era_calculator.dart
@@ -11,7 +11,7 @@ import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 /// YearMonthDay arguments can be assumed to be valid for the relevant calendar,
 /// but other arguments should be validated. (Eras should be validated for nullity as well
 /// as for the presence of a particular era.)
-@internal
+@isInternal
 abstract class EraCalculator
 {
   final Iterable<Era> eras;

--- a/lib/src/calendars/fixed_month_yearmonthday_calculator.dart
+++ b/lib/src/calendars/fixed_month_yearmonthday_calculator.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// As the month length is fixed various calculations can be optimised.
 /// This implementation assumes any additional days after twelve
 /// months fall into a thirteenth month.
-@internal
+@isInternal
 abstract class FixedMonthYearMonthDayCalculator extends RegularYearMonthDayCalculator {
   static const int _daysInMonth = 30;
 

--- a/lib/src/calendars/gj_era_calculator.dart
+++ b/lib/src/calendars/gj_era_calculator.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 
 /// Era calculator for Gregorian and Julian calendar systems, which use BC and AD.
 @immutable
-@internal
+@isInternal
 class GJEraCalculator extends EraCalculator {
   final int _maxYearOfBc;
   final int _maxYearOfAd;

--- a/lib/src/calendars/gj_yearmonthday_calculator.dart
+++ b/lib/src/calendars/gj_yearmonthday_calculator.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class GJYearMonthDayCalculator extends RegularYearMonthDayCalculator {
   // These arrays are NOT public. We trust ourselves not to alter the array.
   // They use zero-based array indexes so the that valid range of months is

--- a/lib/src/calendars/gregorian_yearmonthday_calculator.dart
+++ b/lib/src/calendars/gregorian_yearmonthday_calculator.dart
@@ -51,7 +51,7 @@ const int _lastOptimizedYear = 2100;
 const int _firstOptimizedDay = -25567;
 const int _lastOptimizedDay = 47846;
 
-@internal
+@isInternal
 class GregorianYearMonthDayCalculator extends GJYearMonthDayCalculator {
   static const int minGregorianYear = -9998;
   static const int maxGregorianYear = 9999;

--- a/lib/src/calendars/hebrew_month_converter.dart
+++ b/lib/src/calendars/hebrew_month_converter.dart
@@ -5,7 +5,7 @@
 import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Conversions between civil and scriptural month numbers in the Hebrew calendar system.
-@internal
+@isInternal
 abstract class HebrewMonthConverter {
   /// Given a civil month number and a year in which it occurs, this method returns
   /// the equivalent scriptural month number.

--- a/lib/src/calendars/hebrew_scriptural_calculator.dart
+++ b/lib/src/calendars/hebrew_scriptural_calculator.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// Implementation of the algorithms described in
 /// http://www.cs.tau.ac.il/~nachum/calendar-book/papers/calendar.ps, using scriptural
 /// month numbering.
-@internal
+@isInternal
 abstract class HebrewScripturalCalculator {
   static const int maxYear = 9999;
   static const int minYear = 1;

--- a/lib/src/calendars/hebrew_yearmonthday_calculator.dart
+++ b/lib/src/calendars/hebrew_yearmonthday_calculator.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// See [CalendarSystem.getHebrewCalendar] for details. This is effectively
 /// an adapter around [HebrewScripturalCalculator].
-@internal
+@isInternal
 class HebrewYearMonthDayCalculator extends YearMonthDayCalculator {
   static const int _unixEpochDayAtStartOfYear1 = -2092590;
   static const int _monthsPerLeapCycle = 235;

--- a/lib/src/calendars/islamic_yearmonthday_calculator.dart
+++ b/lib/src/calendars/islamic_yearmonthday_calculator.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 class IslamicYearMonthDayCalculator extends RegularYearMonthDayCalculator {
   /// Days in a pair of months, in days.
   static const int _monthPairLength = 59;

--- a/lib/src/calendars/julian_yearmonthday_calculator.dart
+++ b/lib/src/calendars/julian_yearmonthday_calculator.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 
-@internal 
+@isInternal 
 class JulianYearMonthDayCalculator extends GJYearMonthDayCalculator {
   static const int _averageDaysPer10JulianYears = 3653; // Ideally 365.25 per year
 

--- a/lib/src/calendars/persian_yearmonthday_calculator.dart
+++ b/lib/src/calendars/persian_yearmonthday_calculator.dart
@@ -11,7 +11,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 ///
 /// The constructor uses IsLeapYear to precompute lots of data; it is therefore important that
 /// the implementation of IsLeapYear in subclasses uses no instance fields.
-@internal
+@isInternal
 abstract class PersianYearMonthDayCalculator extends RegularYearMonthDayCalculator {
   static const int _daysPerNonLeapYear = (31 * 6) + (30 * 5) + 29;
   static const int _daysPerLeapYear = _daysPerNonLeapYear + 1;
@@ -111,7 +111,7 @@ abstract class PersianYearMonthDayCalculator extends RegularYearMonthDayCalculat
 
 /// Persian calendar using the simple 33-year cycle of 1, 5, 9, 13, 17, 22, 26, or 30.
 /// This corresponds to System.Globalization.PersianCalendar before .NET 4.6.
-@internal
+@isInternal
 class PersianSimple extends PersianYearMonthDayCalculator {
   // This is a long because we're notionally handling 33 bits. The top bit is
   // false anyway, but IsLeapYear shifts a long for simplicity, so let's be consistent with that.
@@ -145,7 +145,7 @@ class PersianSimple extends PersianYearMonthDayCalculator {
 }
 
 /// Persian calendar based on Birashk's subcycle/cycle/grand cycle scheme.
-@internal
+@isInternal
 class PersianArithmetic extends PersianYearMonthDayCalculator {
   PersianArithmetic() : super._(-492267);
 
@@ -160,7 +160,7 @@ class PersianArithmetic extends PersianYearMonthDayCalculator {
 // todo: what?
 /// Persian calendar based on stored BCL 4.6 information (avoids complex arithmetic for
 /// midday in Tehran).
-@internal
+@isInternal
 class PersianAstronomical extends PersianYearMonthDayCalculator {
   // Ugly, but the simplest way of embedding a big chunk of binary data...
   static final List<int> _astronomicalLeapYearBits = base64.decode(

--- a/lib/src/calendars/regular_yearmonthday_calculator.dart
+++ b/lib/src/calendars/regular_yearmonthday_calculator.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 
-@internal
+@isInternal
 abstract class RegularYearMonthDayCalculator extends YearMonthDayCalculator {
   final int _monthsInYear;
 

--- a/lib/src/calendars/simple_week_year_rule.dart
+++ b/lib/src/calendars/simple_week_year_rule.dart
@@ -14,7 +14,7 @@ import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 /// year, and the end of the week in the following calendar year, but the whole
 /// week is in the same week-year.)
 @immutable
-@internal
+@isInternal
 class SimpleWeekYearRule implements WeekYearRule {
   final int _minDaysInFirstWeek;
   final DayOfWeek _firstDayOfWeek;

--- a/lib/src/calendars/single_era_calculator.dart
+++ b/lib/src/calendars/single_era_calculator.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/calendars/time_machine_calendars.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Implementation of [EraCalculator] for calendars which only have a single era.
-@internal 
+@isInternal 
 class SingleEraCalculator extends EraCalculator {
   final Era _era;
 

--- a/lib/src/calendars/um_al_qura_yearmonthday_calculator.dart
+++ b/lib/src/calendars/um_al_qura_yearmonthday_calculator.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// Implementation of the Um Al Qura calendar, using the tabular data in the BCL. This is fetched
 /// on construction and cached - we just need to know the length of each month of each year, which is
 /// cheap as the current implementation only covers 183 years.
-@internal
+@isInternal
 class UmAlQuraYearMonthDayCalculator extends RegularYearMonthDayCalculator {
   static const int _averageDaysPer10Years = 3544;
 

--- a/lib/src/calendars/year_start_cache_entry.dart
+++ b/lib/src/calendars/year_start_cache_entry.dart
@@ -30,7 +30,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// The fact that each cache entry is only 32 bits means that we can safely use the cache from multiple
 /// threads without locking. 32-bit aligned values are guaranteed to be accessed atomically, so we know we'll
 /// never get the value for one year with the validation bits for another, for example.
-@internal
+@isInternal
 class YearStartCacheEntryVM {
   static const int _cacheIndexBits = 10;
   static const int _cacheIndexMask = 1023; // _cacheSize - 1;
@@ -86,7 +86,7 @@ class YearStartCacheEntryVM {
   int get startOfYearDays => _value >> _entryValidationBits;
 }
 
-@internal
+@isInternal
 class YearStartCacheEntry {
   static const int _cacheIndexBits = 10;
   static const int _cacheIndexMask = 1023; // _cacheSize - 1;

--- a/lib/src/calendars/yearmonthday_calculator.dart
+++ b/lib/src/calendars/yearmonthday_calculator.dart
@@ -12,7 +12,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// The core of date calculations in Time Machine. This class *only* cares about absolute years, and only
 /// dates - it has no time aspects at all, nor era-related aspects.
 // todo: IComparer<YearMonthDay>
-@internal
+@isInternal
 abstract class YearMonthDayCalculator {
   /// Cache to speed up working out when a particular year starts.
   /// See the [YearStartCacheEntry] documentation and [GetStartOfYearInDays]

--- a/lib/src/duration.dart
+++ b/lib/src/duration.dart
@@ -8,7 +8,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class ITime {
   // This is 104249991 days
   static const int maxDays = maxMillis ~/ TimeConstants.millisecondsPerDay; // (1 << 24) - 1;

--- a/lib/src/fields/date_period_fields.dart
+++ b/lib/src/fields/date_period_fields.dart
@@ -6,7 +6,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/fields/time_machine_fields.dart';
 
 /// All the period fields.
-@internal
+@isInternal
 abstract class DatePeriodFields
 {
   static final IDatePeriodField daysField = FixedLengthDatePeriodField(1);

--- a/lib/src/fields/fixed_length_date_period_field.dart
+++ b/lib/src/fields/fixed_length_date_period_field.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/fields/time_machine_fields.dart';
 
 /// Date period field for fixed-length periods (weeks and days).
 @immutable
-@internal
+@isInternal
 class FixedLengthDatePeriodField implements IDatePeriodField {
   final int _unitDays;
 

--- a/lib/src/fields/i_date_period_field.dart
+++ b/lib/src/fields/i_date_period_field.dart
@@ -6,7 +6,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// General representation of the difference between two dates in a particular time unit,
 /// such as 'days' or "months".
-@internal
+@isInternal
 abstract class IDatePeriodField {
   /// Adds a duration value (which may be negative) to the date. This may not
   /// be reversible; for example, adding a month to January 30th will result in

--- a/lib/src/fields/months_period_field.dart
+++ b/lib/src/fields/months_period_field.dart
@@ -6,7 +6,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/fields/time_machine_fields.dart';
 
 /// Period field which uses a [YearMonthDayCalculator] to add/subtract months.
-@internal
+@isInternal
 class MonthsPeriodField implements IDatePeriodField {
   MonthsPeriodField();
 

--- a/lib/src/fields/time_period_field.dart
+++ b/lib/src/fields/time_period_field.dart
@@ -62,7 +62,7 @@ class AddTimeCalc {
 /// finding the object etc. It turned out to make about 10% difference, at the cost of quite a bit
 /// of code elegance.
 @immutable
-@internal
+@isInternal
 class TimePeriodField
 {
   static final TimePeriodField nanoseconds = TimePeriodField._(1);

--- a/lib/src/fields/years_period_field.dart
+++ b/lib/src/fields/years_period_field.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 import 'package:time_machine/src/fields/time_machine_fields.dart';
 
 /// Period field which uses a [YearMonthDayCalculator] to add/subtract years.
-@internal class YearsPeriodField implements IDatePeriodField {
+@isInternal class YearsPeriodField implements IDatePeriodField {
   YearsPeriodField();
 
   LocalDate add(LocalDate localDate, int value) {

--- a/lib/src/instant.dart
+++ b/lib/src/instant.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class IInstant {
   // NodaTime enforces a range of -9998-01-01 and 9999-12-31 ... Is this related to CalendarCalculators?
   // These correspond to -9998-01-01 and 9999-12-31 respectively.

--- a/lib/src/interval.dart
+++ b/lib/src/interval.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 // import 'package:quiver_hashcode/hashcode.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class IInterval {
   static Instant rawEnd(Interval interval) => interval._rawEnd;
 }

--- a/lib/src/localdate.dart
+++ b/lib/src/localdate.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class ILocalDate {
   static LocalDate trusted(YearMonthDayCalendar yearMonthDayCalendar) => LocalDate._trusted(yearMonthDayCalendar);
   // static LocalDate fromDaysSinceEpoch(int daysSinceEpoch, [CalendarSystem calendar]) => new LocalDate.fromEpochDay(daysSinceEpoch, calendar);

--- a/lib/src/localdatetime.dart
+++ b/lib/src/localdatetime.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 // TODO(feature): Calendar-neutral comparer.
 
-@internal
+@isInternal
 abstract class ILocalDateTime {
   static LocalInstant toLocalInstant(LocalDateTime localDateTime) => localDateTime._toLocalInstant();
   static LocalDateTime fromInstant(LocalInstant localInstant) => LocalDateTime._localInstant(localInstant);

--- a/lib/src/localinstant.dart
+++ b/lib/src/localinstant.dart
@@ -12,7 +12,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// offset is). This class has been slimmed down considerably over time - it's used much less
 /// than it used to be... almost solely for time zones.
 @immutable
-@internal
+@isInternal
 class LocalInstant {
   static final LocalInstant beforeMinValue = LocalInstant._trusted(IInstant.beforeMinValue.epochDay, deliberatelyInvalid: true);
   static final LocalInstant afterMaxValue = LocalInstant._trusted(IInstant.afterMaxValue.epochDay, deliberatelyInvalid: true);

--- a/lib/src/localtime.dart
+++ b/lib/src/localtime.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 // Note: documentation that refers to the LocalDateTime type within this class must use the fully-qualified
 // reference to avoid being resolved to the LocalDateTime property instead.
 
-@internal
+@isInternal
 abstract class ILocalTime {
   static LocalTime trustedNanoseconds(int nanoseconds) => LocalTime._(nanoseconds);
 

--- a/lib/src/offset_datetime.dart
+++ b/lib/src/offset_datetime.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 // import 'package:quiver_hashcode/hashcode.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class IOffsetDateTime {
   static OffsetDateTime fullTrust(LocalDateTime localDateTime, Offset offset) =>
       OffsetDateTime(localDateTime, offset);

--- a/lib/src/period.dart
+++ b/lib/src/period.dart
@@ -34,7 +34,7 @@ class _TimeComponentsBetweenResult {
   _TimeComponentsBetweenResult(this.hours, this.minutes, this.seconds, this.milliseconds, this.microseconds, this.nanoseconds);
 }
 
-@internal
+@isInternal
 abstract class IPeriod {
   static int daysBetween(LocalDate start, LocalDate end) => Period._daysBetween(start, end);
 
@@ -741,7 +741,7 @@ class Period {
 // todo: why is this private, it's used in period_tests?
 /// Equality comparer which simply normalizes periods before comparing them.
 @private class NormalizingPeriodEqualityComparer {
-  @internal static final NormalizingPeriodEqualityComparer instance = NormalizingPeriodEqualityComparer._();
+  @isInternal static final NormalizingPeriodEqualityComparer instance = NormalizingPeriodEqualityComparer._();
 
   NormalizingPeriodEqualityComparer._() {
   }

--- a/lib/src/platforms/platform_io.dart
+++ b/lib/src/platforms/platform_io.dart
@@ -8,13 +8,13 @@ import 'dart:typed_data';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 /// This class packages platform specific input-output functions that are initialized by the appropriate Platform Provider
-@internal
+@isInternal
 abstract class PlatformIO {
-  @internal Future<ByteData> getBinary(String path, String filename);
+  @isInternal Future<ByteData> getBinary(String path, String filename);
   // JSON.decode returns a dynamic -- will this change in Dart 2.0?
-  @internal Future<dynamic> getJson(String path, String filename);
+  @isInternal Future<dynamic> getJson(String path, String filename);
 
-  @internal static PlatformIO local;
+  @isInternal static PlatformIO local;
 }
 
 Future initialize(dynamic arg) {

--- a/lib/src/text/annual_date_pattern.dart
+++ b/lib/src/text/annual_date_pattern.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// todo: investigate, probably not needed for Dart
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing TimeFormatInfo.InvariantInfo...
-@internal
+@isInternal
 abstract class AnnualDatePatterns {
   static AnnualDatePattern create(String patternText, TimeMachineFormatInfo formatInfo, AnnualDate templateValue) =>
       AnnualDatePattern._create(patternText, formatInfo, templateValue);

--- a/lib/src/text/annual_date_pattern_parser.dart
+++ b/lib/src/text/annual_date_pattern_parser.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
 /// Parser for patterns of [AnnualDate] values.
-@internal
+@isInternal
 class AnnualDatePatternParser implements IPatternParser<AnnualDate> {
   final AnnualDate _templateValue;
 
@@ -73,7 +73,7 @@ class AnnualDatePatternParser implements IPatternParser<AnnualDate> {
 
 /// Bucket to put parsed values in, ready for later result calculation. This type is also used
 /// by AnnualDateTimePattern to store and calculate values.
-@internal
+@isInternal
 class AnnualDateParseBucket extends ParseBucket<AnnualDate> {
   final AnnualDate templateValue;
   int monthOfYearNumeric = 0;

--- a/lib/src/text/delegates.dart
+++ b/lib/src/text/delegates.dart
@@ -8,6 +8,6 @@ import 'package:time_machine/src/text/time_machine_text.dart';
 // This file contains all the delegates declared within the NodaTime.Text namespace.
 // It's simpler than either nesting them or giving them a file per delegate.
 // @internal typedef CharacterHandler = void Function<TResult, TBucket extends ParseBucket<TResult>>(PatternCursor patternCursor, SteppedPatternBuilder<TResult, TBucket> patternBuilder);
-@internal
+@isInternal
 typedef void CharacterHandler<TResult, TBucket extends ParseBucket<TResult>>(PatternCursor patternCursor, SteppedPatternBuilder<TResult, TBucket> patternBuilder);
 

--- a/lib/src/text/duration_pattern.dart
+++ b/lib/src/text/duration_pattern.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 // Nested class for ease of type initialization
-@internal
+@isInternal
 abstract class TimePatterns {
   static final TimePattern roundtripPatternImpl = TimePattern.createWithInvariantCulture('-D:hh:mm:ss.FFFFFFFFF');
   static String format(Time time, String patternText, Culture culture) =>

--- a/lib/src/text/duration_pattern_parser.dart
+++ b/lib/src/text/duration_pattern_parser.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class TimePatternParser implements IPatternParser<Time> {
   static final Map</*char*/String, CharacterHandler<Time, _TimeParseBucket>> _patternCharacterHandlers =
   {

--- a/lib/src/text/fixed_format_info_pattern_parser.dart
+++ b/lib/src/text/fixed_format_info_pattern_parser.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
 
 /// A pattern parser for a single format info, which caches patterns by text/style.
-@internal
+@isInternal
 class FixedFormatInfoPatternParser<T> {
   // It would be unusual to have more than 50 different patterns for a specific culture
   // within a real app.

--- a/lib/src/text/format_helper.dart
+++ b/lib/src/text/format_helper.dart
@@ -6,7 +6,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/utility/time_machine_utilities.dart';
 
 ///   Provides helper methods for formatting values using pattern strings.
-@internal
+@isInternal
 abstract class FormatHelper {
   // '0': 48; '9': 57
   static const int _zeroCodeUnit = 48;

--- a/lib/src/text/globalization/culture.dart
+++ b/lib/src/text/globalization/culture.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class ICultures {
   static void set currentCulture(Culture value) { Cultures._currentCulture = value; }
   static void loadAllCulturesInformation_SetFlag() {

--- a/lib/src/text/globalization/culture_io.dart
+++ b/lib/src/text/globalization/culture_io.dart
@@ -9,7 +9,7 @@ import 'dart:collection';
 import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/platforms/platform_io.dart';
 
-@internal
+@isInternal
 class CultureLoader {
   static Future<CultureLoader> load() async {
     var map = await _loadCultureMapping();
@@ -86,7 +86,7 @@ class CultureLoader {
   // static String get locale => Platform.localeName;
 }
 
-@internal
+@isInternal
 class CultureReader extends BinaryReader {
   CultureReader(ByteData binary, [int offset = 0]) : super(binary, offset);
 

--- a/lib/src/text/globalization/pattern_resources.dart
+++ b/lib/src/text/globalization/pattern_resources.dart
@@ -5,7 +5,7 @@
 import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/text/globalization/time_machine_globalization.dart';
 
-@internal
+@isInternal
 abstract class PatternResources
 {
   // Resource files have a structure similar to:

--- a/lib/src/text/globalization/time_machine_format_info.dart
+++ b/lib/src/text/globalization/time_machine_format_info.dart
@@ -20,7 +20,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 /// [Culture] itself may be mutable. If the [Culture] is mutated after initialization, results are not
 /// guaranteed: some aspects of the [Culture] may be extracted at initialization time, others may be
 /// extracted on first demand but cached, and others may be extracted on-demand each time.
-@internal
+@isInternal
 class TimeMachineFormatInfo {
   // todo: remove for Dart
   // Names that we can use to check for broken Mono behaviour.

--- a/lib/src/text/i_partial_pattern.dart
+++ b/lib/src/text/i_partial_pattern.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// when one pattern is embedded within another.
 ///
 /// [T]: The type of value to be parsed or formatted.
-@internal
+@isInternal
 @interface
 abstract class IPartialPattern<T> implements IPattern<T>
 {

--- a/lib/src/text/instant_pattern.dart
+++ b/lib/src/text/instant_pattern.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class InstantPatterns {
   /// Class whose existence is solely to avoid type initialization order issues, most of which stem
   /// from needing NodaFormatInfo.InvariantInfo...

--- a/lib/src/text/instant_pattern_parser.dart
+++ b/lib/src/text/instant_pattern_parser.dart
@@ -12,7 +12,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 ///
 /// Supported standard patterns:
 ///  * g: general; the UTC ISO-8601 instant in the style uuuu-MM-ddTHH:mm:ssZ
-@internal
+@isInternal
 class InstantPatternParser implements IPatternParser<Instant> {
   static const String generalPatternText = "uuuu'-'MM'-'dd'T'HH':'mm':'ss'Z'";
   static const String beforeMinValueText = 'StartOfTime';

--- a/lib/src/text/localdate_pattern.dart
+++ b/lib/src/text/localdate_pattern.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class LocalDatePatterns {
   /// Class whose existence is solely to avoid type initialization order issues, most of which stem
   /// from needing TimeFormatInfo.InvariantInfo...

--- a/lib/src/text/localdate_pattern_parser.dart
+++ b/lib/src/text/localdate_pattern_parser.dart
@@ -14,7 +14,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 const int _twoDigitYearMax = 30;
 
 /// Parser for patterns of [LocalDate] values.
-@internal
+@isInternal
 class LocalDatePatternParser implements IPatternParser<LocalDate> {
   final LocalDate _templateValue;
 
@@ -78,7 +78,7 @@ class LocalDatePatternParser implements IPatternParser<LocalDate> {
 // todo: was a sub class of LocalDatePatternParser
 /// Bucket to put parsed values in, ready for later result calculation. This type is also used
 /// by LocalDateTimePattern to store and calculate values.
-@internal
+@isInternal
 class LocalDateParseBucket extends ParseBucket<LocalDate> {
   final LocalDate templateValue;
 
@@ -109,7 +109,7 @@ class LocalDateParseBucket extends ParseBucket<LocalDate> {
     return IParseResult.mismatchedText<TResult>(cursor, 'g');
   }
 
-  @internal
+  @isInternal
   @override
   ParseResult<LocalDate> calculateValue(PatternFields usedFields, String text) {
     if (usedFields.hasAny(PatternFields.embeddedDate)) {

--- a/lib/src/text/localdatetime_pattern.dart
+++ b/lib/src/text/localdatetime_pattern.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing TimeMachineFormatInfo.InvariantInfo... (todo: does this affect us in Dart Land?)
-@internal
+@isInternal
 abstract class LocalDateTimePatterns
 {
   static final LocalDateTimePattern generalIsoPatternImpl = LocalDateTimePattern.createWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss");

--- a/lib/src/text/localdatetime_pattern_parser.dart
+++ b/lib/src/text/localdatetime_pattern_parser.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
 /// Parser for patterns of [LocalDateTime] values.
-@internal
+@isInternal
 class LocalDateTimePatternParser implements IPatternParser<LocalDateTime> {
   // Split the template value into date and time once, to avoid doing it every time we parse.
   final LocalDate _templateValueDate;
@@ -112,7 +112,7 @@ class LocalDateTimePatternParser implements IPatternParser<LocalDateTime> {
   }
 }
 
-@internal
+@isInternal
 class LocalDateTimeParseBucket extends ParseBucket<LocalDateTime> {
   final /*LocalDatePatternParser.*/LocalDateParseBucket date;
   final /*LocalTimePatternParser.*/LocalTimeParseBucket time;

--- a/lib/src/text/localtime_pattern.dart
+++ b/lib/src/text/localtime_pattern.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class LocalTimePatterns {
   // todo: we may not need _Patterns classes for our Dart port
   /// Class whose existence is solely to avoid type initialization order issues, most of which stem

--- a/lib/src/text/localtime_pattern_parser.dart
+++ b/lib/src/text/localtime_pattern_parser.dart
@@ -5,7 +5,7 @@
 import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Pattern parser for [LocalTime] values.
-@internal
+@isInternal
 class LocalTimePatternParser implements IPatternParser<LocalTime> {
   final LocalTime _templateValue;
 
@@ -77,7 +77,7 @@ class LocalTimePatternParser implements IPatternParser<LocalTime> {
 
 /// Bucket to put parsed values in, ready for later result calculation. This type is also used
 /// by LocalDateTimePattern to store and calculate values.
-@internal
+@isInternal
 class LocalTimeParseBucket extends ParseBucket<LocalTime> {
   final LocalTime templateValue;
 

--- a/lib/src/text/offset_date_pattern.dart
+++ b/lib/src/text/offset_date_pattern.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing NodaFormatInfo.InvariantInfo...
-@internal
+@isInternal
 abstract class OffsetDatePatterns {
   static final OffsetDatePattern generalIsoPatternImpl = OffsetDatePattern._create(
       "uuuu'-'MM'-'ddo<G>", TimeMachineFormatInfo.invariantInfo, defaultTemplateValue);

--- a/lib/src/text/offset_date_pattern_parser.dart
+++ b/lib/src/text/offset_date_pattern_parser.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class OffsetDatePatternParser implements IPatternParser<OffsetDate> {
   final OffsetDate _templateValue;
 

--- a/lib/src/text/offset_datetime_pattern.dart
+++ b/lib/src/text/offset_datetime_pattern.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing NodaFormatInfo.InvariantInfo...
-@internal
+@isInternal
 abstract class OffsetDateTimePatterns {
   static final OffsetDateTimePattern generalIsoPatternImpl = OffsetDateTimePattern._create(
       "uuuu'-'MM'-'dd'T'HH':'mm':'sso<G>", TimeMachineFormatInfo.invariantInfo, defaultTemplateValue);

--- a/lib/src/text/offset_datetime_pattern_parser.dart
+++ b/lib/src/text/offset_datetime_pattern_parser.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class OffsetDateTimePatternParser implements IPatternParser<OffsetDateTime> {
   final OffsetDateTime _templateValue;
 

--- a/lib/src/text/offset_pattern.dart
+++ b/lib/src/text/offset_pattern.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class OffsetPatterns {
   static String format(Offset offset, String patternText, Culture culture) =>
       TimeMachineFormatInfo

--- a/lib/src/text/offset_pattern_parser.dart
+++ b/lib/src/text/offset_pattern_parser.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class OffsetPatternParser implements IPatternParser<Offset> {
   static final Map<String /*char*/, CharacterHandler<Offset, _OffsetParseBucket>> _patternCharacterHandlers = {
     '%': SteppedPatternBuilder.handlePercent /**<Offset, OffsetParseBucket>*/,

--- a/lib/src/text/offset_time_pattern.dart
+++ b/lib/src/text/offset_time_pattern.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing TimeMachineFormatInfo.InvariantInfo...
-@internal
+@isInternal
 class OffsetTimePatterns {
   //static OffsetTimePattern _GeneralIsoPatternImpl;
   //@internal static OffsetTimePattern get GeneralIsoPatternImpl => _GeneralIsoPatternImpl ??= OffsetTimePattern.Create(

--- a/lib/src/text/offset_time_pattern_parser.dart
+++ b/lib/src/text/offset_time_pattern_parser.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/globalization/time_machine_globalization.d
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class OffsetTimePatternParser implements IPatternParser<OffsetTime> {
   final OffsetTime _templateValue;
 

--- a/lib/src/text/parse_bucket.dart
+++ b/lib/src/text/parse_bucket.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
 /// Base class for 'buckets' of parse data - as field values are parsed, they are stored in a bucket,
 /// then the final value is calculated at the end.
-@internal
+@isInternal
 abstract class ParseBucket<T> {
   /// Performs the final conversion from fields to a value. The parse can still fail here, if there
   /// are incompatible field values.

--- a/lib/src/text/parse_result.dart
+++ b/lib/src/text/parse_result.dart
@@ -130,7 +130,7 @@ class ParseResult<T> {
       ParseResult<T>._error(Preconditions.checkNotNull(errorProvider, 'errorProvider'), false);
 }
 
-@internal
+@isInternal
 abstract class IParseResult {
   static bool continueAfterErrorWithMultipleFormats(ParseResult result) => result._continueAfterErrorWithMultipleFormats;
 

--- a/lib/src/text/patterns/date_pattern_helper.dart
+++ b/lib/src/text/patterns/date_pattern_helper.dart
@@ -29,7 +29,7 @@ class _MonthFormatActionHolder<TResult, TBucket extends ParseBucket<TResult>> ex
 
 /// Common methods used when parsing dates - these are used from both LocalDateTimePatternParser
 /// and LocalDatePatternParser.
-@internal
+@isInternal
 abstract class DatePatternHelper {
   /// Creates a character handler for the year-of-era specifier (y).
   static CharacterHandler<TResult, TBucket> createYearOfEraHandler<TResult, TBucket extends ParseBucket<TResult>>

--- a/lib/src/text/patterns/i_pattern_parser.dart
+++ b/lib/src/text/patterns/i_pattern_parser.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/text/time_machine_text.dart';
 /// Internal interface used by FixedFormatInfoPatternParser. Unfortunately
 /// even though this is internal, implementations must either use public methods
 /// or explicit interface implementation.
-@internal
+@isInternal
 abstract class IPatternParser<T>
 {
   IPattern<T> parsePattern(String pattern, TimeMachineFormatInfo formatInfo);

--- a/lib/src/text/patterns/pattern_cursor.dart
+++ b/lib/src/text/patterns/pattern_cursor.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/text/time_machine_text.dart';
 
 
 /// Extends [TextCursor] to simplify parsing patterns such as 'uuuu-MM-dd'.
-@internal
+@isInternal
 class PatternCursor extends TextCursor {
   /// The character signifying the start of an embedded pattern.
   static const String embeddedPatternStart = '<';

--- a/lib/src/text/patterns/pattern_fields.dart
+++ b/lib/src/text/patterns/pattern_fields.dart
@@ -11,7 +11,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 /// by all parser types for simplicity, although most fields aren't used by most parsers.
 /// Pattern fields don't necessarily have corresponding duration or date/time fields,
 /// due to concepts such as 'sign'.
-@internal
+@isInternal
 @immutable
 class PatternFields {
   final int _value;

--- a/lib/src/text/patterns/stepped_pattern_builder.dart
+++ b/lib/src/text/patterns/stepped_pattern_builder.dart
@@ -12,7 +12,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 // was originally a class inside SteppedPatternBuilder
 // internal delegate ParseResult<TResult> ParseAction(ValueCursor cursor, TBucket bucket);
 // @internal typedef ParseAction = ParseResult<TResult> Function<TResult, TBucket extends ParseBucket<TResult>>(ValueCursor cursor, TBucket bucket);
-@internal
+@isInternal
 typedef ParseResult<TResult> ParseAction<TResult, TBucket extends ParseBucket<TResult>>(ValueCursor cursor, TBucket bucket);
 
 class _FindLongestMatchCursor {
@@ -22,7 +22,7 @@ class _FindLongestMatchCursor {
 
 /// Builder for a pattern which implements parsing and formatting as a sequence of steps applied
 /// in turn.
-@internal
+@isInternal
 class SteppedPatternBuilder<TResult, TBucket extends ParseBucket<TResult>> {
   static const int _aCodeUnit = 97;
   static const int _zCodeUnit = 122;
@@ -500,7 +500,7 @@ class SteppedPatternBuilder<TResult, TBucket extends ParseBucket<TResult>> {
 
 // todo: this was a C# hack ... it was inside SteppedPatternBuilder original ... this hack is messy
 /// Hack to handle genitive month names - we only know what we need to do *after* we've parsed the whole pattern.
-@internal
+@isInternal
 abstract class IPostPatternParseFormatAction<TResult>
 {
   Function(TResult, StringBuffer) buildFormatAction(PatternFields finalFields);

--- a/lib/src/text/patterns/time_pattern_helper.dart
+++ b/lib/src/text/patterns/time_pattern_helper.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
 /// Common methods used when parsing dates - these are used from LocalDateTimePatternParser,
 /// OffsetPatternParser and LocalTimePatternParser.
-@internal
+@isInternal
 abstract class TimePatternHelper
 {
   /// Creates a character handler for a dot (period). This is *not* culture sensitive - it is

--- a/lib/src/text/text_cursor.dart
+++ b/lib/src/text/text_cursor.dart
@@ -12,7 +12,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 /// have ref parameters indicating failures, unlike subclasses. This class is used as the basis for both
 /// value and pattern parsing, so can make no judgement about what's wrong (i.e. it wouldn't know what
 /// type of failure to indicate). Instead, methods return Boolean values to indicate success or failure.
-@internal
+@isInternal
 abstract class TextCursor {
   /// Gets the length of the string being parsed.
   final int length;

--- a/lib/src/text/text_error_messages.dart
+++ b/lib/src/text/text_error_messages.dart
@@ -4,7 +4,7 @@
 
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal
+@isInternal
 abstract class TextErrorMessages
 {
   static const String ambiguousLocalTime = 'The local date/time is ambiguous in the target time zone.';

--- a/lib/src/text/value_cursor.dart
+++ b/lib/src/text/value_cursor.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 import 'package:time_machine/src/utility/time_machine_utilities.dart';
 import 'package:time_machine/src/text/time_machine_text.dart';
 
-@internal
+@isInternal
 class ValueCursor extends TextCursor {
   // '0': 48; '9': 57
   static const int _zeroCodeUnit = 48;

--- a/lib/src/text/zoneddatetime_pattern.dart
+++ b/lib/src/text/zoneddatetime_pattern.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 /// Class whose existence is solely to avoid type initialization order issues, most of which stem
 /// from needing TimeMachineFormatInfo.InvariantInfo...
-@internal
+@isInternal
 abstract class ZonedDateTimePatterns
 {
   static final ZonedDateTimePattern generalFormatOnlyPatternImpl = ZonedDateTimePattern.createWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss z '('o<g>')'", null);

--- a/lib/src/text/zoneddatetime_pattern_parser.dart
+++ b/lib/src/text/zoneddatetime_pattern_parser.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 import 'package:time_machine/src/text/time_machine_text.dart';
 import 'package:time_machine/src/text/patterns/time_machine_patterns.dart';
 
-@internal
+@isInternal
 class ZonedDateTimePatternParser implements IPatternParser<ZonedDateTime> {
   final ZonedDateTime _templateValue;
   final DateTimeZoneProvider _zoneProvider;

--- a/lib/src/time_machine_internal.dart
+++ b/lib/src/time_machine_internal.dart
@@ -69,7 +69,7 @@ class _Internal{
 /// What I might do is just separate the classes into a public facing interface only classes and a set of
 /// implementation classes (much like a lot to the io\stream classes).
 /// src/public ~ src/internal ~ or I could just do one large public file with all the classes
-const Object internal = const _Internal();
+const Object isInternal = const _Internal();
 
 /// This was internal in Noda Time, but I'm considering keeping it public in Time Machine
 const Object wasInternal = const _Internal();

--- a/lib/src/timezones/cached_datetimezone.dart
+++ b/lib/src/timezones/cached_datetimezone.dart
@@ -19,7 +19,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 /// was more effort than it was worth to update. The mechanism is still available for future
 /// expansion though.
 // sealed
-@internal
+@isInternal
 class CachedDateTimeZone extends DateTimeZone {
   final ZoneIntervalMap _map;
 

--- a/lib/src/timezones/caching_zoneinterval_map.dart
+++ b/lib/src/timezones/caching_zoneinterval_map.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 
 /// Helper methods for creating IZoneIntervalMaps which cache results.
-@internal
+@isInternal
 abstract class CachingZoneIntervalMap
 {
 // Currently the only implementation is HashArrayCache. This container class is mostly for historical

--- a/lib/src/timezones/fixed_datetimezone.dart
+++ b/lib/src/timezones/fixed_datetimezone.dart
@@ -16,7 +16,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 /// Basic [DateTimeZone] implementation that has a fixed name key and offset i.e.
 /// no daylight savings.
 @immutable
-@internal
+@isInternal
 class FixedDateTimeZone extends DateTimeZone {
   final ZoneInterval _interval;
 

--- a/lib/src/timezones/partial_zoneinterval_map.dart
+++ b/lib/src/timezones/partial_zoneinterval_map.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 
 /// Like ZoneIntervalMap, representing just part of the time line. The intervals returned by this map
 /// are clamped to the portion of the time line being represented, to make it easier to work with.
-@internal
+@isInternal
 class PartialZoneIntervalMap
 {
   final ZoneIntervalMap _map;

--- a/lib/src/timezones/precalculated_datetimezone.dart
+++ b/lib/src/timezones/precalculated_datetimezone.dart
@@ -17,7 +17,7 @@ typedef _offsetAggregator = Offset Function(Offset x, Offset y);
 /// container for the initial zone intervals and a pointer to the time zone that handles all of
 /// the rest until the end of time.
 @immutable // todo: we need immutable lists?
-@internal
+@isInternal
 class PrecalculatedDateTimeZone extends DateTimeZone {
   final List<ZoneInterval> _periods;
   final ZoneIntervalMapWithMinMax _tailZone;

--- a/lib/src/timezones/single_zoneinterval_map.dart
+++ b/lib/src/timezones/single_zoneinterval_map.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 /// Implementation of IZoneIntervalMap which just returns a single interval (provided on construction) regardless of
 /// the instant requested.
 @immutable
-@internal
+@isInternal
 class SingleZoneIntervalMap implements ZoneIntervalMap {
   final ZoneInterval _interval;
 

--- a/lib/src/timezones/standard_daylight_alternating_map.dart
+++ b/lib/src/timezones/standard_daylight_alternating_map.dart
@@ -35,7 +35,7 @@ class _TransitionRecurrenceResult {
 /// only be used as part of a zone which will only ask it for values within the right
 /// portion of the timeline.
 @immutable
-@internal
+@isInternal
 class StandardDaylightAlternatingMap implements ZoneIntervalMapWithMinMax  {
   final Offset _standardOffset;
   final ZoneRecurrence _standardRecurrence;

--- a/lib/src/timezones/transition.dart
+++ b/lib/src/timezones/transition.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// A transition between two offsets, usually for daylight saving reasons. This type only knows about
 /// the new offset, and the transition point.
 @immutable
-@internal
+@isInternal
 class Transition {
   final Instant instant;
 

--- a/lib/src/timezones/transition_mode.dart
+++ b/lib/src/timezones/transition_mode.dart
@@ -7,7 +7,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 
 /// Specifies how transitions are calculated. Whether relative to UTC, the time zones standard
 /// offset, or the wall (or daylight savings) offset.
-@internal
+@isInternal
 class TransitionMode {
   final int _value;
 

--- a/lib/src/timezones/tzdb_datetimezone_source.dart
+++ b/lib/src/timezones/tzdb_datetimezone_source.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 
 // todo: the Internal Classes here make me sad
 
-@internal
+@isInternal
 abstract class IDateTimeZoneProviders {
   static void set defaultProvider(DateTimeZoneProvider provider) => DateTimeZoneProviders._defaultProvider = provider;
 }
@@ -29,7 +29,7 @@ abstract class DateTimeZoneProviders {
   static DateTimeZoneProvider get defaultProvider => _defaultProvider;
 }
 
-@internal
+@isInternal
 class ITzdbDateTimeZoneSource {
   static void loadAllTimeZoneInformation_SetFlag() {
     if (TzdbDateTimeZoneSource._cachedTzdbIndex != null) throw StateError('loadAllTimeZone flag may not be set after TZDB is initalized.');

--- a/lib/src/timezones/tzdb_io.dart
+++ b/lib/src/timezones/tzdb_io.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 import 'package:time_machine/src/platforms/platform_io.dart';
 
-@internal
+@isInternal
 class TzdbIndex {
   static Future<TzdbIndex> load() async {
     var _jsonMap = await _loadIdMapping();
@@ -101,7 +101,7 @@ class TzdbIndex {
 // https://github.com/dart-lang/language/issues/41
 // todo: normalize behavior so these classes look more alike
 
-@internal
+@isInternal
 class DateTimeZoneReader extends BinaryReader {
   DateTimeZoneReader(ByteData binary, [int offset = 0]) : super(binary, offset);
 
@@ -139,7 +139,7 @@ abstract class DateTimeZoneType
   static const int precalculated = 2;
 }
 
-@internal
+@isInternal
 abstract class IDateTimeZoneWriter {
   void writeZoneInterval(ZoneInterval zoneInterval);
   Future close();

--- a/lib/src/timezones/tzdb_zone_1970_location.dart
+++ b/lib/src/timezones/tzdb_zone_1970_location.dart
@@ -75,7 +75,7 @@ class TzdbZone1970Location {
     return TzdbZone1970Location._(Comment, Countries, latitudeSeconds, longitudeSeconds, ZoneId);
   }
 
-  @internal void write(IDateTimeZoneWriter writer) {
+  @isInternal void write(IDateTimeZoneWriter writer) {
     // We considered writing out the ISO-3166 file as a separate field,
     // so we can reuse objects, but we don't actually waste very much space this way,
     // due to the string pool... and the increased code complexity isn't worth it.
@@ -93,7 +93,7 @@ class TzdbZone1970Location {
     writer.writeString(comment);
   }
 
-  @internal static TzdbZone1970Location read(DateTimeZoneReader reader)
+  @isInternal static TzdbZone1970Location read(DateTimeZoneReader reader)
   {
     int latitudeSeconds = reader.readInt32();
     int longitudeSeconds = reader.readInt32();

--- a/lib/src/timezones/tzdb_zone_location.dart
+++ b/lib/src/timezones/tzdb_zone_location.dart
@@ -71,7 +71,7 @@ class TzdbZoneLocation
     return TzdbZoneLocation._(Comment, CountryCode, CountryName, latitudeSeconds, longitudeSeconds, ZoneId);
   }
 
-  @internal void write(IDateTimeZoneWriter writer)
+  @isInternal void write(IDateTimeZoneWriter writer)
   {
     writer.writeInt32(_latitudeSeconds);
     writer.writeInt32(_longitudeSeconds);
@@ -81,7 +81,7 @@ class TzdbZoneLocation
     writer.writeString(comment);
   }
 
-  @internal static TzdbZoneLocation read(DateTimeZoneReader reader) {
+  @isInternal static TzdbZoneLocation read(DateTimeZoneReader reader) {
     int latitudeSeconds = reader.readInt32(); // reader.ReadSignedCount();
     int longitudeSeconds = reader.readInt32(); // reader.ReadSignedCount();
     String countryName = reader.readString();

--- a/lib/src/timezones/zone_equality_comparer.dart
+++ b/lib/src/timezones/zone_equality_comparer.dart
@@ -130,7 +130,7 @@ bool _checkOption(ZoneEqualityComparerOptions options, ZoneEqualityComparerOptio
   return (options & candidate).value != 0;
 }
 
-@internal
+@isInternal
 abstract class IZoneEqualityComparer {
   /// Returns the interval over which this comparer operates.
   @visibleForTesting
@@ -260,7 +260,7 @@ class ZoneEqualityComparer {
   }
 }
 
-@internal
+@isInternal
 class ZoneIntervalEqualityComparer {
   final ZoneEqualityComparerOptions _options;
   final Interval _interval;

--- a/lib/src/timezones/zone_local_mapping.dart
+++ b/lib/src/timezones/zone_local_mapping.dart
@@ -8,7 +8,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 // Note: documentation that refers to the LocalDateTime type within this class must use the fully-qualified
 // reference to avoid being resolved to the LocalDateTime property instead.
 
-@internal
+@isInternal
 abstract class IZoneLocalMapping {
   static ZoneLocalMapping newZoneLocalMapping
       (DateTimeZone zone, LocalDateTime localDateTime, ZoneInterval earlyInterval, ZoneInterval lateInterval, int count) => 

--- a/lib/src/timezones/zone_recurrence.dart
+++ b/lib/src/timezones/zone_recurrence.dart
@@ -14,7 +14,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// before the time zones were normalized (i.e. when they were still tightly longitude-based,
 /// with multiple towns in the same country observing different times).
 @immutable
-@internal
+@isInternal
 class ZoneRecurrence {
   final LocalInstant _maxLocalInstant;
   final LocalInstant _minLocalInstant;

--- a/lib/src/timezones/zone_year_offset.dart
+++ b/lib/src/timezones/zone_year_offset.dart
@@ -23,7 +23,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 /// Finally the [Mode] property deterines whether the [timeOfDay] value
 /// is added to the calculated offset to generate an offset within the day.
 @immutable
-@internal
+@isInternal
 class ZoneYearOffset {
   /// An offset that specifies the beginning of the year.
   static final ZoneYearOffset StartOfYear = ZoneYearOffset(TransitionMode.wall, 1, 1, 0, false, LocalTime.midnight);

--- a/lib/src/timezones/zoneinterval.dart
+++ b/lib/src/timezones/zoneinterval.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 // todo: thought: should I adopt the *of() Pattern from flutter?
-@internal
+@isInternal
 abstract class IZoneInterval {
   static Instant rawStart(ZoneInterval zoneInterval) => zoneInterval._rawStart;
   static Instant rawEnd(ZoneInterval zoneInterval) => zoneInterval._rawEnd;

--- a/lib/src/timezones/zoneinterval_map.dart
+++ b/lib/src/timezones/zoneinterval_map.dart
@@ -11,7 +11,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 /// Benchmarking shows that a delegate may be slightly faster here, but the difference
 /// isn't very significant even for very fast calls (cache hits). The interface ends up
 /// feeling slightly cleaner elsewhere in the code.
-@internal
+@isInternal
 @interface
 abstract class ZoneIntervalMap
 {
@@ -20,7 +20,7 @@ abstract class ZoneIntervalMap
 
 // This is slightly ugly, but it allows us to use any time zone as the tail
 // zone for PrecalculatedDateTimeZone, which is handy for testing.
-@internal
+@isInternal
 @interface
 abstract class ZoneIntervalMapWithMinMax extends ZoneIntervalMap
 {

--- a/lib/src/utility/binary_reader.dart
+++ b/lib/src/utility/binary_reader.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 import 'package:time_machine/src/time_machine_internal.dart';
 
 // todo: collate into an input and output folder
-@internal
+@isInternal
 class BinaryReader {
   // todo: should this be private?
   final ByteData binary;

--- a/lib/src/utility/cache.dart
+++ b/lib/src/utility/cache.dart
@@ -12,7 +12,7 @@ import 'dart:collection';
 ///
 /// [TKey]: Type of key
 /// [TValue]: Type of value
-@internal
+@isInternal
 class Cache<TKey, TValue> {
   final int _size;
   // @private final object mutex = new object();

--- a/lib/src/yearmonthday.dart
+++ b/lib/src/yearmonthday.dart
@@ -6,7 +6,7 @@
 import 'package:time_machine/src/time_machine_internal.dart';
 
 // todo: bit packing didn't work on JS -- I feel like it should though (getting the class functional now, will investigate later)
-@internal
+@isInternal
 class YearMonthDay implements Comparable<YearMonthDay> {
   final int year;
   final int month;

--- a/lib/src/yearmonthday_and_calendar.dart
+++ b/lib/src/yearmonthday_and_calendar.dart
@@ -9,7 +9,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
 // This is a Year - Month - Day - Calendar TUPLE -- this not actually a Calendar;
 // todo: test bit packing
-@internal
+@isInternal
 class YearMonthDayCalendar {
   // These constants are internal so they can be used in YearMonthDay
   static const int calendarBits = 6; // Up to 64 calendars.

--- a/lib/src/zoneddatetime.dart
+++ b/lib/src/zoneddatetime.dart
@@ -15,7 +15,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 // Note: documentation that refers to the LocalDateTime type within this class must use the fully-qualified
 // reference to avoid being resolved to the LocalDateTime property instead.
 
-@internal
+@isInternal
 abstract class IZonedDateTime {
   static ZonedDateTime trusted(OffsetDateTime offsetDateTime, DateTimeZone zone) => ZonedDateTime._(offsetDateTime, zone);
 }

--- a/test/calendars/badi_calendar_system_test.dart
+++ b/test/calendars/badi_calendar_system_test.dart
@@ -630,7 +630,7 @@ int BadiMonth(LocalDate input)
 /// <summary>
 /// Get a text representation of the date.
 /// </summary>
-@internal String AsBadiString(LocalDate input)
+@isInternal String AsBadiString(LocalDate input)
 {
   var year = input.year;
   var month = BadiMonth(input);

--- a/test/text/annual_date_pattern_test.dart
+++ b/test/text/annual_date_pattern_test.dart
@@ -20,7 +20,7 @@ Future main() async {
 
 @Test()
 class AnnualDatePatternTest extends PatternTestBase<AnnualDate> {
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -77,7 +77,7 @@ class AnnualDatePatternTest extends PatternTestBase<AnnualDate> {
       ..parameters.addAll([ 'T'])
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..pattern = 'MM dd MMMM'
       ..text = '10 09 January'
@@ -117,7 +117,7 @@ class AnnualDatePatternTest extends PatternTestBase<AnnualDate> {
       ..parameters.addAll([ 35, 2])
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     // Month parsing should be case-insensitive
     Data.monthDay(10, 3)
       ..pattern = 'MMM dd'
@@ -145,9 +145,9 @@ class AnnualDatePatternTest extends PatternTestBase<AnnualDate> {
       ..culture = TestCultures.GenitiveNameTestCultureWithLeadingNames,
   ];
 
-  @internal List<Data> FormatOnlyData = [];
+  @isInternal List<Data> FormatOnlyData = [];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
     // Standard patterns
     Data.monthDay(10, 20)
       ..pattern = 'G'
@@ -214,8 +214,8 @@ class AnnualDatePatternTest extends PatternTestBase<AnnualDate> {
       ..text = 'Oct 09 10',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   Future CreateWithCurrentCulture() async
@@ -277,7 +277,7 @@ class Data extends PatternTestData<AnnualDate> {
 
   Data.monthDay(int month, int day) : super(AnnualDate(month, day));
 
-  @internal
+  @isInternal
   @override
   IPattern<AnnualDate> CreatePattern() =>
       AnnualDatePattern.createWithInvariantCulture(super.pattern)

--- a/test/text/instant_pattern_test.dart
+++ b/test/text/instant_pattern_test.dart
@@ -18,7 +18,7 @@ Future main() async {
 
 @Test()
 class InstantPatternTest extends PatternTestBase<Instant> {
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -51,7 +51,7 @@ class InstantPatternTest extends PatternTestBase<Instant> {
       ..parameters.addAll(['F', 9]),
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..text = 'rubbish'
       .. pattern = "yyyyMMdd'T'HH:mm:ss"
@@ -69,9 +69,9 @@ class InstantPatternTest extends PatternTestBase<Instant> {
       ..parameters.addAll(['H', 't', 'LocalTime']),
   ];
 
-  @internal List<Data> ParseOnlyData = [];
+  @isInternal List<Data> ParseOnlyData = [];
 
-  @internal List<Data> FormatOnlyData = [];
+  @isInternal List<Data> FormatOnlyData = [];
 
   @Test()
   void IsoHandlesCommas() {
@@ -105,7 +105,7 @@ class InstantPatternTest extends PatternTestBase<Instant> {
 
   /// Common test data for both formatting and parsing. A test should be placed here unless is truly
   /// cannot be run both ways. This ensures that as many round-trip type tests are performed as possible.
-  @internal final List<Data> FormatAndParseData = [
+  @isInternal final List<Data> FormatAndParseData = [
     Data.fromUtc(2012, 1, 31, 17, 36, 45)
       ..text = '2012-01-31T17:36:45'
       ..pattern = "yyyy-MM-dd'T'HH:mm:ss",
@@ -135,9 +135,9 @@ class InstantPatternTest extends PatternTestBase<Instant> {
       ..pattern = "uuuu-MM-ddTHH:mm:ss'Z'",
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 }
 
 /// A container for test data for formatting and parsing [LocalTime] objects.
@@ -149,7 +149,7 @@ class InstantPatternTest extends PatternTestBase<Instant> {
   Data.fromUtc(int year, int month, int day, int hour, int minute, int second)
       : this(Instant.utc(year, month, day, hour, minute, second));
 
-  @internal
+  @isInternal
   @override
   IPattern<Instant> CreatePattern() =>
       InstantPattern.createWithInvariantCulture(super.pattern).withCulture(culture);

--- a/test/text/localdate_pattern_test.dart
+++ b/test/text/localdate_pattern_test.dart
@@ -20,7 +20,7 @@ Future main() async {
 class LocalDatePatternTest extends PatternTestBase<LocalDate> {
   @private final LocalDate SampleLocalDate = LocalDate(1976, 6, 19);
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -117,7 +117,7 @@ class LocalDatePatternTest extends PatternTestBase<LocalDate> {
       ..parameters.addAll(['y', 3]),
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..pattern = 'yyyy gg'
       ..text = '2011 NodaEra'
@@ -248,7 +248,7 @@ class LocalDatePatternTest extends PatternTestBase<LocalDate> {
       ..message = TextErrorMessages.noMatchingCalendarSystem,
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     // Alternative era names
     Data.ymd(0, 10, 3)
       ..pattern = 'yyyy MM dd gg'
@@ -296,7 +296,7 @@ class LocalDatePatternTest extends PatternTestBase<LocalDate> {
       ..culture = TestCultures.GenitiveNameTestCultureWithLeadingNames,
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     // Would parse back to 2011
     Data.ymd(1811, 7, 3)
       ..pattern = 'yy M d'
@@ -311,7 +311,7 @@ class LocalDatePatternTest extends PatternTestBase<LocalDate> {
       ..text = '94 7 3',
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
     // Standard patterns
     // Invariant culture uses the crazy MM/dd/yyyy format. Blech.
     Data.ymd(2011, 10, 20)
@@ -501,9 +501,9 @@ class LocalDatePatternTest extends PatternTestBase<LocalDate> {
       ..text = '-1234 01 02',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   /*
 @Test()
@@ -584,7 +584,7 @@ class Data extends PatternTestData<LocalDate> {
   Data.ymdc(int year, int month, int day, CalendarSystem calendar)
       : super(LocalDate(year, month, day, calendar));
 
-  @internal
+  @isInternal
   @override
   IPattern<LocalDate> CreatePattern() =>
       LocalDatePattern.createWithInvariantCulture(super.pattern)

--- a/test/text/localdatetime_pattern_test.dart
+++ b/test/text/localdatetime_pattern_test.dart
@@ -55,11 +55,11 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
 
   // The standard example date/time used in all the MSDN samples, which means we can just cut and paste
   // the expected results of the standard patterns.
-  @internal static final LocalDateTime MsdnStandardExample = TestLocalDateTimes.MsdnStandardExample;
-  @internal static final LocalDateTime MsdnStandardExampleNoMillis = TestLocalDateTimes.MsdnStandardExampleNoMillis;
+  @isInternal static final LocalDateTime MsdnStandardExample = TestLocalDateTimes.MsdnStandardExample;
+  @isInternal static final LocalDateTime MsdnStandardExampleNoMillis = TestLocalDateTimes.MsdnStandardExampleNoMillis;
   @private static final LocalDateTime MsdnStandardExampleNoSeconds = TestLocalDateTimes.MsdnStandardExampleNoSeconds;
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -95,7 +95,7 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
       ..parameters.addAll(['<']),
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..pattern = 'dd MM yyyy HH:mm:ss'
       ..text = 'Complete mismatch'
@@ -135,7 +135,7 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
       ..message = TextErrorMessages.invalidHour24,
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     Data.ymd(2011, 10, 19, 16, 05, 20)
       ..pattern = 'dd MM yyyy'
       ..text = '19 10 2011'
@@ -182,7 +182,7 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
       ..text = '2011-10-19 24',
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     Data.ymd(2011, 10, 19, 16, 05, 20)
       ..pattern = 'ddd yyyy'
       ..text = 'Wed 2011',
@@ -195,7 +195,7 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
       ..text = '1976-06-19T21:13:34.1234567'
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
     // Standard patterns (US)
     // Full date/time (short time)
     Data(MsdnStandardExampleNoSeconds)
@@ -453,9 +453,9 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
       ..text = '10/24/2015 11:55',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void WithCalendar() {
@@ -615,7 +615,7 @@ class LocalDateTimePatternTest extends PatternTestBase<LocalDateTime> {
   Data.dt(LocalDate date, LocalTime time) : super(date.at(time));
 
 
-  @internal
+  @isInternal
   @override
   IPattern<LocalDateTime> CreatePattern() =>
       LocalDateTimePattern.createWithInvariantCulture(super.pattern)

--- a/test/text/localtime_pattern_test.dart
+++ b/test/text/localtime_pattern_test.dart
@@ -52,7 +52,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
   @private static final Culture PmOnlyCulture = CreateCustomAmPmCulture('', "pm");
   @private static final Culture NoAmOrPmCulture = CreateCustomAmPmCulture('', "");
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -119,7 +119,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..parameters.addAll(['T'])
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..text = '17 6'
       ..pattern = 'HH h'
@@ -150,7 +150,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..message = TextErrorMessages.missingAmPmDesignator
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     Data.hms(0, 0, 0, 400)
       ..text = '4'
       ..pattern = '%f',
@@ -289,7 +289,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..pattern = 'ss.FF',
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     Data.hms(5, 6, 7, 8)
       ..text = ''
       ..pattern = '%F',
@@ -408,7 +408,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..pattern = '%s',
   ];
 
-  @internal List<Data> DefaultPatternData = [
+  @isInternal List<Data> DefaultPatternData = [
     // Invariant culture uses HH:mm:ss for the 'long' pattern
     Data.hms(5, 0, 0, 0)
       ..text = '05:00:00',
@@ -432,7 +432,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..text = '5:12:34 AM',
   ];
 
-  @internal final List<Data> TemplateValueData = [
+  @isInternal final List<Data> TemplateValueData = [
     // Pattern specifies nothing - template value is passed through
     Data(LocalTime(1, 2, 3, ns: 4 * TimeConstants.nanosecondsPerMillisecond + 5 * 100))
       ..culture = TestCultures.EnUs
@@ -501,7 +501,7 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
 
   /// Common test data for both formatting and parsing. A test should be placed here unless is truly
   /// cannot be run both ways. This ensures that as many round-trip type tests are performed as possible.
-  @internal final List<Data> FormatAndParseData = [
+  @isInternal final List<Data> FormatAndParseData = [
     Data(LocalTime.midnight)
       ..culture = TestCultures.EnUs
       ..text = '.'
@@ -946,9 +946,9 @@ class LocalTimePatternTest extends PatternTestBase<LocalTime> {
       ..pattern = "HH':'mm':'ss;FFFFFFF",
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @private static Culture CreateCustomAmPmCulture(String amDesignator, String pmDesignator) {
     return Culture('ampmDesignators'/*Culture.invariantCultureId*/, (
@@ -1079,7 +1079,7 @@ expect(SampleDateTime.toString(patternText, culture), pattern.Format(SampleLocal
   }
 
 
-  @internal @override IPattern<LocalTime> CreatePattern() =>
+  @isInternal @override IPattern<LocalTime> CreatePattern() =>
   LocalTimePattern.createWithInvariantCulture(super.pattern)
       .withTemplateValue(template)
       .withCulture(culture);

--- a/test/text/offset_date_pattern_test.dart
+++ b/test/text/offset_date_pattern_test.dart
@@ -29,7 +29,7 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
 
   @private static final Offset AthensOffset = Offset.hours(3);
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -61,7 +61,7 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
       ..message = TextErrorMessages.escapeAtEndOfString,
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..pattern = 'dd MM yyyy'
       ..text = 'Complete mismatch'
@@ -78,9 +78,9 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
       ..message = TextErrorMessages.noMatchingCalendarSystem,
   ];
 
-  @internal List<Data> ParseOnlyData = [];
+  @isInternal List<Data> ParseOnlyData = [];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     Data.ymdo(2011, 10, 19)
       ..pattern = 'ddd yyyy'
       ..text = 'Wed 2011',
@@ -92,7 +92,7 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
       ..text = '2009-06-15'
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
     // Copied from LocalDateTimePatternTest
     // Calendar patterns are invariant
     Data(MsdnStandardExample)
@@ -142,9 +142,9 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
       ..text = '15 June 2009 (A.D.) +01',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void CreateWithInvariantCulture() {
@@ -210,7 +210,7 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
   void ParseNull() => AssertParseNull(OffsetDatePattern.generalIso);
 }
 
-@internal /*sealed*/ class Data extends PatternTestData<OffsetDate>
+@isInternal /*sealed*/ class Data extends PatternTestData<OffsetDate>
 {
 // Default to the start of the year 2000 UTC
 /*protected*/ @override OffsetDate get defaultTemplate => OffsetDatePatterns.defaultTemplateValue;
@@ -218,14 +218,14 @@ class OffsetDatePatternTest extends PatternTestBase<OffsetDate> {
 /// Initializes a new instance of the [Data] class.
 ///
 /// [value]: The value.
-@internal Data([OffsetDate value]) : super(value ?? OffsetDatePatterns.defaultTemplateValue)
+@isInternal Data([OffsetDate value]) : super(value ?? OffsetDatePatterns.defaultTemplateValue)
 {
 }
 
-@internal Data.ymdo(int year, int month, int day, [Offset offset])
+@isInternal Data.ymdo(int year, int month, int day, [Offset offset])
     : super(LocalDate(year, month, day).withOffset(offset ?? Offset.zero));
 
-@internal @override IPattern<OffsetDate> CreatePattern() =>
+@isInternal @override IPattern<OffsetDate> CreatePattern() =>
     OffsetDatePattern.createWithCulture(super.pattern, super.culture, template);
 }
 

--- a/test/text/offset_datetime_pattern_test.dart
+++ b/test/text/offset_datetime_pattern_test.dart
@@ -30,7 +30,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
 
   @private static final Offset AthensOffset = Offset.hours(3);
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -92,7 +92,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ..message = TextErrorMessages.escapeAtEndOfString,
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     // Failures copied from LocalDateTimePatternTest
     Data()
       ..pattern = 'dd MM yyyy HH:mm:ss'
@@ -133,7 +133,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ..message = TextErrorMessages.timeSeparatorMismatch,
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     // Parse-only tests from LocalDateTimeTest.
     Data.c(2011, 10, 19, 16, 05, 20)
       ..pattern = 'dd MM yyyy'
@@ -182,7 +182,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ..text = '2011-10-19 24',
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     Data.c(2011, 10, 19, 16, 05, 20)
       ..pattern = 'ddd yyyy'
       ..text = 'Wed 2011',
@@ -193,7 +193,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ..text = '2009-06-15 13:45:30.09'
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
     // Copied from LocalDateTimePatternTest
     // Calendar patterns are invariant
     Data(MsdnStandardExample)
@@ -374,9 +374,9 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ..text = '15 June 2009 (A.D.) 1:45:30.09 PM +01',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void CreateWithInvariantCulture() {
@@ -444,28 +444,28 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
   void ParseNull() => AssertParseNull(OffsetDateTimePattern.extendedIso);
 }
 
-@internal /*sealed*/ class Data extends PatternTestData<OffsetDateTime> {
+@isInternal /*sealed*/ class Data extends PatternTestData<OffsetDateTime> {
   // Default to the start of the year 2000 UTC
   /*protected*/ @override OffsetDateTime get defaultTemplate => OffsetDateTimePatterns.defaultTemplateValue;
 
   /// Initializes a new instance of the [Data] class.
   ///
   /// [value]: The value.
-  @internal Data([OffsetDateTime value]) : super(value ?? OffsetDateTimePatterns.defaultTemplateValue);
+  @isInternal Data([OffsetDateTime value]) : super(value ?? OffsetDateTimePatterns.defaultTemplateValue);
 
-  @internal Data.a(int year, int month, int day)
+  @isInternal Data.a(int year, int month, int day)
       : super(LocalDateTime(year, month, day, 0, 0, 0).withOffset(Offset.zero));
 
-  @internal Data.b(int year, int month, int day, int hour, int minute, Offset offset)
+  @isInternal Data.b(int year, int month, int day, int hour, int minute, Offset offset)
       : super(LocalDateTime(year, month, day, hour, minute, 0).withOffset(offset));
 
-  @internal Data.c(int year, int month, int day, int hour, int minute, int second)
+  @isInternal Data.c(int year, int month, int day, int hour, int minute, int second)
       : super(LocalDateTime(year, month, day, hour, minute, second).withOffset(Offset.zero));
 
-  @internal Data.d(int year, int month, int day, int hour, int minute, int second, Offset offset)
+  @isInternal Data.d(int year, int month, int day, int hour, int minute, int second, Offset offset)
       : super(LocalDateTime(year, month, day, hour, minute, second).withOffset(offset));
 
-  @internal Data.e(int year, int month, int day, int hour, int minute, int second, int millis)
+  @isInternal Data.e(int year, int month, int day, int hour, int minute, int second, int millis)
       : super(LocalDateTime(
       year,
       month,
@@ -476,7 +476,7 @@ class OffsetDateTimePatternTest extends PatternTestBase<OffsetDateTime> {
       ms: millis).withOffset(Offset.zero));
 
 
-  @internal
+  @isInternal
   @override
   IPattern<OffsetDateTime> CreatePattern() =>
       OffsetDateTimePattern.createWithCulture(super.pattern, super.culture, template);

--- a/test/text/offset_pattern_test.dart
+++ b/test/text/offset_pattern_test.dart
@@ -23,7 +23,7 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
   static const String Nbsp = "\u00a0";
 
   /// Test data that can only be used to test formatting.
-  @internal final List<Data> FormatOnlyData = [
+  @isInternal final List<Data> FormatOnlyData = [
     Data.hms(3, 0, 0)
       ..culture = TestCultures.EnUs
       ..text = ''
@@ -130,7 +130,7 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
   ];
 
   /// Test data that can only be used to test successful parsing.
-  @internal final List<Data> ParseOnlyData = [
+  @isInternal final List<Data> ParseOnlyData = [
     Data(Offset.zero)
       ..culture = TestCultures.EnUs
       ..text = '*'
@@ -169,7 +169,7 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
   ];
 
   /// Test data for invalid patterns
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data(Offset.zero)
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -257,7 +257,7 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
   ];
 
   /// Tests for parsing failures (of values)
-  @internal final List<Data> ParseFailureData = [
+  @isInternal final List<Data> ParseFailureData = [
     Data(Offset.zero)
       ..culture = TestCultures.EnUs
       ..text = ''
@@ -377,7 +377,7 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
 
   /// Common test data for both formatting and parsing. A test should be placed here unless is truly
   /// cannot be run both ways. This ensures that as many round-trip type tests are performed as possible.
-  @internal final List<Data> FormatAndParseData = [
+  @isInternal final List<Data> FormatAndParseData = [
 /*XXX*/ Data(Offset.zero)
       ..culture = TestCultures.EnUs
       ..text = '.'
@@ -650,9 +650,9 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
       ..pattern = 'Z+HH:mm',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   @TestCaseSource(#ParseData)
@@ -713,13 +713,13 @@ class OffsetPatternTest extends PatternTestBase<Offset> {
   {
   }*/
 
-  @internal
+  @isInternal
   @override
   IPattern<Offset> CreatePattern() =>
       OffsetPattern.createWithInvariantCulture(super.pattern)
           .withCulture(culture);
 
-  @internal
+  @isInternal
   @override
   IPartialPattern<Offset> CreatePartialPattern() =>
       OffsetPatterns.underlyingPattern(

--- a/test/text/offset_time_pattern_test.dart
+++ b/test/text/offset_time_pattern_test.dart
@@ -28,7 +28,7 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
 
   @private static final Offset AthensOffset = Offset.hours(3);
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -52,7 +52,7 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
       ..parameters.addAll(['x', 'OffsetTime']),
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     // Failures copied from LocalDateTimePatternTest
     Data()
       ..pattern = 'HH:mm:ss'
@@ -72,7 +72,7 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
       ..parameters.addAll(['H', 't', 'LocalTime']),
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     // Parsing using the semi-colon 'comma dot' specifier
     Data.d(16, 05, 20, 352)
       ..pattern = 'HH:mm:ss;fff'
@@ -82,7 +82,7 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
       ..text = '16:05:20,352',
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     // Our template value has an offset of 0, but the value has an offset of 1.
     // The pattern doesn't include the offset, so that information is lost - no round-trip.
     Data(MsdnStandardExample)
@@ -97,7 +97,7 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
       ..culture = TestCultures.FrFr,
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
 // Copied from LocalDateTimePatternTest
 
     // Standard patterns (all invariant)
@@ -136,9 +136,9 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
       ..text = '1:45:30.09 PM +01',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData =>
+  @isInternal Iterable<Data> get FormatData =>
       [FormatOnlyData, FormatAndParseData].expand((x) => x
       );
 
@@ -196,29 +196,29 @@ class OffsetTimePatternTest extends PatternTestBase<OffsetTime> {
   void ParseNull() => AssertParseNull(OffsetTimePattern.extendedIso);
 }
 
-@internal /*sealed*/class Data extends PatternTestData<OffsetTime> {
+@isInternal /*sealed*/class Data extends PatternTestData<OffsetTime> {
   // Default to the start of the year 2000 UTC
   /*protected*/ @override OffsetTime get defaultTemplate => OffsetTimePatterns.defaultTemplateValue;
 
   /// Initializes a new instance of the [Data] class.
   ///
   /// [value]: The value.
-  @internal Data([OffsetTime value]) : super(value ?? OffsetTimePatterns.defaultTemplateValue);
+  @isInternal Data([OffsetTime value]) : super(value ?? OffsetTimePatterns.defaultTemplateValue);
 
-  @internal Data.a(int hour, int minute, Offset offset) : this.c(hour, minute, 0, offset);
+  @isInternal Data.a(int hour, int minute, Offset offset) : this.c(hour, minute, 0, offset);
 
-  @internal Data.b(int hour, int minute, int second) : this.d(hour, minute, second, 0);
+  @isInternal Data.b(int hour, int minute, int second) : this.d(hour, minute, second, 0);
 
-  @internal Data.c(int hour, int minute, int second, Offset offset)
+  @isInternal Data.c(int hour, int minute, int second, Offset offset)
       : this.e(hour, minute, second, 0, offset);
 
-  @internal Data.d(int hour, int minute, int second, int millis)
+  @isInternal Data.d(int hour, int minute, int second, int millis)
       : this.e(hour, minute, second, millis, Offset.zero);
 
-  @internal Data.e(int hour, int minute, int second, int millis, Offset offset)
+  @isInternal Data.e(int hour, int minute, int second, int millis, Offset offset)
       : this(LocalTime(hour, minute, second, ms: millis).withOffset(offset));
 
-  @internal
+  @isInternal
   @override
   IPattern<OffsetTime> CreatePattern() =>
       OffsetTimePattern.createWithCulture(super.pattern, super.culture, template);

--- a/test/text/pattern_test_data.dart
+++ b/test/text/pattern_test_data.dart
@@ -11,46 +11,46 @@ import 'package:time_machine/src/utility/time_machine_utilities.dart';
 /// include properties which are irrelevant to the pattern tests but which are used by the BCL-style
 /// formatting tests (e.g. thread culture).
 abstract class PatternTestData<T> {
-  @internal final T Value;
+  @isInternal final T Value;
 
   /*final*/
   T defaultTemplate;
 
   /// Culture of the pattern.
-  @internal Culture culture = Culture.invariant;
+  @isInternal Culture culture = Culture.invariant;
 
   /// Standard pattern, expected to format/parse the same way as Pattern.
-  @internal IPattern<T> standardPattern;
+  @isInternal IPattern<T> standardPattern;
 
   /// This lets the JS_Test_Gen know what to put. (This is a total cop-out ~ complexity level is too high)
   /// rational: there are 33 usages of StandardPattern, it's easier to annotate than spend a week creating the most beautiful reflection program
-  @internal String standardPatternCode;
+  @isInternal String standardPatternCode;
 
   /// Pattern text.
-  @internal String pattern;
+  @isInternal String pattern;
 
   /// String value to be parsed, and expected result of formatting.
-  @internal String text;
+  @isInternal String text;
 
   /// Template value to specify in the pattern
-  @internal T template;
+  @isInternal T template;
 
   /// Extra description for the test case
-  @internal String description;
+  @isInternal String description;
 
   /// Message format to verify for exceptions.
-  @internal String message;
+  @isInternal String message;
 
   /// Message parameters to verify for exceptions.
-  @internal final List parameters = List();
+  @isInternal final List parameters = List();
 
-  @internal PatternTestData(this.Value) {
+  @isInternal PatternTestData(this.Value) {
     template = defaultTemplate;
   }
 
-  @internal IPattern<T> CreatePattern();
+  @isInternal IPattern<T> CreatePattern();
 
-  @internal void TestParse() {
+  @isInternal void TestParse() {
     assert(message == null);
     IPattern<T> pattern = CreatePattern();
     var result = pattern.parse(text);
@@ -64,7 +64,7 @@ abstract class PatternTestData<T> {
     }
   }
 
-  @internal void TestFormat() {
+  @isInternal void TestFormat() {
     assert(message == null);
     IPattern<T> pattern = CreatePattern();
     expect(pattern.format(Value), text);
@@ -74,7 +74,7 @@ abstract class PatternTestData<T> {
     }
   }
 
-  @internal void TestParsePartial() {
+  @isInternal void TestParsePartial() {
     var pattern = CreatePartialPattern();
     assert(message == null);
     var cursor = ValueCursor('^' + text + "#");
@@ -88,11 +88,11 @@ abstract class PatternTestData<T> {
     assert('#' == cursor.current);
   }
 
-  @internal /*virtual*/ IPartialPattern<T> CreatePartialPattern() {
+  @isInternal /*virtual*/ IPartialPattern<T> CreatePartialPattern() {
     throw UnimplementedError();
   }
 
-  @internal void TestAppendFormat() {
+  @isInternal void TestAppendFormat() {
     assert(message == null);
     var pattern = CreatePattern();
     var builder = StringBuffer('x');
@@ -101,7 +101,7 @@ abstract class PatternTestData<T> {
     expect(builder.toString(), 'x' + text );
   }
 
-  @internal void TestInvalidPattern() {
+  @isInternal void TestInvalidPattern() {
     String expectedMessage = FormatMessage(message, parameters);
     try {
       CreatePattern();

--- a/test/text/patterns/pattern_cursor_test.dart
+++ b/test/text/patterns/pattern_cursor_test.dart
@@ -18,7 +18,7 @@ Future main() async {
 
 @Test()
 class PatternCursorTest extends TextCursorTestBase {
-  @internal
+  @isInternal
   @override
   TextCursor MakeCursor(String value) {
     return PatternCursor(value);

--- a/test/text/patterns/stepped_pattern_builder_test.dart
+++ b/test/text/patterns/stepped_pattern_builder_test.dart
@@ -87,7 +87,7 @@ void UnhandledLiteral(String text, bool valid) {
 }
 
 @private class SampleBucket extends ParseBucket<LocalDate> {
-  @internal
+  @isInternal
   @override
   ParseResult<LocalDate> calculateValue(PatternFields usedFields, String value) {
     throw UnimplementedError();

--- a/test/text/period_pattern_normalizing_iso_test.dart
+++ b/test/text/period_pattern_normalizing_iso_test.dart
@@ -18,9 +18,9 @@ Future main() async {
 @Test()
 class PeriodPatternNormalizingIsoTest extends PatternTestBase<Period> {
   // Single null value to keep it from being 'inconclusive'
-  @internal final List<Data> InvalidPatternData = [ null];
+  @isInternal final List<Data> InvalidPatternData = [ null];
 
-  @internal final List<Data> ParseFailureData = [
+  @isInternal final List<Data> ParseFailureData = [
     Data()
       ..text = 'X5H'
       ..message = TextErrorMessages.mismatchedCharacter
@@ -107,7 +107,7 @@ class PeriodPatternNormalizingIsoTest extends PatternTestBase<Period> {
       ..message = TextErrorMessages.expectedEndOfString
   ];
 
-  @internal final List<Data> ParseOnlyData = [
+  @isInternal final List<Data> ParseOnlyData = [
     Data.builder(PeriodBuilder()..hours = 5)
       ..text = 'PT005H',
     Data.builder(PeriodBuilder()..milliseconds = 500)
@@ -129,7 +129,7 @@ class PeriodPatternNormalizingIsoTest extends PatternTestBase<Period> {
       
     The Text is 'P1D2H30M' online... todo: what is happening here? do the tests fail on NodaTime.Test:master?
   */
-  @internal final List<Data> FormatOnlyData = [
+  @isInternal final List<Data> FormatOnlyData = [
     Data.builder(PeriodBuilder()
       ..hours = 25
       ..minutes = 90)
@@ -149,7 +149,7 @@ class PeriodPatternNormalizingIsoTest extends PatternTestBase<Period> {
       ..text = 'P35D',
   ];
 
-  @internal final List<Data> FormatAndParseData = [
+  @isInternal final List<Data> FormatAndParseData = [
     Data(Period.zero)
       ..text = 'P0D',
 
@@ -200,9 +200,9 @@ class PeriodPatternNormalizingIsoTest extends PatternTestBase<Period> {
       ..text = 'PT-0.32S',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   // note: in C# this was a static constructor; a regular constructor works in Dart's test infrastructure
   // Go over all our sequences and change the pattern to use. This is ugly,

--- a/test/text/period_pattern_roundtrip_test.dart
+++ b/test/text/period_pattern_roundtrip_test.dart
@@ -17,9 +17,9 @@ Future main() async {
 
 @Test()
 class PeriodPatternRoundtripTest extends PatternTestBase<Period> {
-  @internal final List<Data> InvalidPatternData = [ null];
+  @isInternal final List<Data> InvalidPatternData = [ null];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     Data()
       ..text = 'X5H'
       ..message = TextErrorMessages.mismatchedCharacter
@@ -81,7 +81,7 @@ class PeriodPatternRoundtripTest extends PatternTestBase<Period> {
       ..parameters.addAll(['-10000000000000000000', 'Period']),
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     Data.builder(PeriodBuilder()..hours = 5)
       ..text = 'PT005H',
     Data.builder(PeriodBuilder()..hours = 5)
@@ -89,9 +89,9 @@ class PeriodPatternRoundtripTest extends PatternTestBase<Period> {
   ];
 
   // This pattern round-trips, so we can always parse what we format.
-  @internal List<Data> FormatOnlyData = [];
+  @isInternal List<Data> FormatOnlyData = [];
 
-  @internal static final List<Data> FormatAndParseData = [
+  @isInternal static final List<Data> FormatAndParseData = [
     Data(Period.zero)
       ..text = 'P',
 
@@ -148,9 +148,9 @@ class PeriodPatternRoundtripTest extends PatternTestBase<Period> {
       ..text = 'PT-9223372036854775808H',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void ParseNull() => AssertParseNull(PeriodPattern.roundtrip);

--- a/test/text/period_pattern_test.dart
+++ b/test/text/period_pattern_test.dart
@@ -22,7 +22,7 @@ class Data extends PatternTestData<Period> {
 
   Data.builder(PeriodBuilder builder) : this(builder.build());
 
-  @internal
+  @isInternal
   @override
   IPattern<Period> CreatePattern() => standardPattern;
 }

--- a/test/text/span_pattern_test.dart
+++ b/test/text/span_pattern_test.dart
@@ -20,7 +20,7 @@ Future main() async {
 @Test()
 class SpanPatternTest extends PatternTestBase<Time> {
   /// Test data that can only be used to test formatting.
-  @internal  final List<Data> FormatOnlyData = [
+  @isInternal  final List<Data> FormatOnlyData = [
     // No sign, so we can't parse it.
     Data.hm(-1, 0)
       ..pattern = 'HH:mm'
@@ -36,10 +36,10 @@ class SpanPatternTest extends PatternTestBase<Time> {
   ];
 
   /// Test data that can only be used to test successful parsing.
-  @internal  final List<Data> ParseOnlyData = [];
+  @isInternal  final List<Data> ParseOnlyData = [];
 
   /// Test data for invalid patterns
-  @internal  final List<Data> InvalidPatternData = [
+  @isInternal  final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -60,7 +60,7 @@ class SpanPatternTest extends PatternTestBase<Time> {
   ];
 
   /// Tests for parsing failures (of values)
-  @internal  final List<Data> ParseFailureData = [
+  @isInternal  final List<Data> ParseFailureData = [
     Data(Time.zero)
       ..pattern = 'H:mm'
       ..text = '1:60'
@@ -143,7 +143,7 @@ class SpanPatternTest extends PatternTestBase<Time> {
 
   /// Common test data for both formatting and parsing. A test should be placed here unless is truly
   /// cannot be run both ways. This ensures that as many round-trip type tests are performed as possible.
-  @internal  final List<Data> FormatAndParseData = [
+  @isInternal  final List<Data> FormatAndParseData = [
     Data.hm(1, 2)
       ..pattern = '+HH:mm'
       ..text = '+01:02',
@@ -255,8 +255,8 @@ class SpanPatternTest extends PatternTestBase<Time> {
       ..Text = '1449551462399.999999999',*/
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void ParseNull() => AssertParseNull(TimePattern.roundtrip);
@@ -296,7 +296,7 @@ class SpanPatternTest extends PatternTestBase<Time> {
   Data.dhmsn(int days, int hours, int minutes, int seconds, int nanoseconds)
       : this(Time(hours: days * 24 + hours) + Time(minutes: minutes) + Time(seconds: seconds) + Time(nanoseconds: nanoseconds));
 
-  @internal
+  @isInternal
   @override
   IPattern<Time> CreatePattern() => TimePattern.createWithCulture(super.pattern, culture);
 }

--- a/test/text/test_cultures.dart
+++ b/test/text/test_cultures.dart
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the Apache License 2.0, as found in the LICENSE.txt file.
 import 'package:time_machine/src/time_machine_internal.dart';
 
-@internal abstract class TestLocalDateTimes {
+@isInternal abstract class TestLocalDateTimes {
   @private static final LocalDateTime SampleLocalDateTime = LocalDateTime(1976, 6, 19, 21, 13, 34).addNanoseconds(123456789);
   @private static final LocalDateTime SampleLocalDateTimeToTicks = LocalDateTime(1976, 6, 19, 21, 13, 34).addNanoseconds(123456700);
   @private static final LocalDateTime SampleLocalDateTimeToMillis = LocalDateTime(
@@ -28,7 +28,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
 
   // The standard example date/time used in all the MSDN samples, which means we can just cut and paste
   // the expected results of the standard patterns.
-  @internal static final LocalDateTime MsdnStandardExample = LocalDateTime(
+  @isInternal static final LocalDateTime MsdnStandardExample = LocalDateTime(
       2009,
       06,
       15,
@@ -36,12 +36,12 @@ import 'package:time_machine/src/time_machine_internal.dart';
       45,
       30,
       ms: 90);
-  @internal static final LocalDateTime MsdnStandardExampleNoMillis = LocalDateTime(2009, 06, 15, 13, 45, 30);
+  @isInternal static final LocalDateTime MsdnStandardExampleNoMillis = LocalDateTime(2009, 06, 15, 13, 45, 30);
   @private static final LocalDateTime MsdnStandardExampleNoSeconds = LocalDateTime(2009, 06, 15, 13, 45, 0);
 }
 
 /// Cultures to use from various tests.
-@internal abstract class TestCultures {
+@isInternal abstract class TestCultures {
   /*
   // Force the cultures to be read-only for tests, to take advantage of caching. Note that on .NET Core,
   // Culture.getCultures doesn't exist, so we have a big long list of cultures, generated against
@@ -52,7 +52,7 @@ import 'package:time_machine/src/time_machine_internal.dart';
       .Select(Culture.ReadOnly)
       .ToList();*/
 
-  @internal static final Culture Invariant = Culture.invariant;
+  @isInternal static final Culture Invariant = Culture.invariant;
 
   static Culture getCulture(String id) {
     switch (id) {

--- a/test/text/text_cursor_test_base_tests.dart
+++ b/test/text/text_cursor_test_base_tests.dart
@@ -68,21 +68,21 @@ abstract class TextCursorTestBase {
     ValidateBeginningOfString(cursor);
   }
 
-  @internal String GetNextCharacter(TextCursor cursor) {
+  @isInternal String GetNextCharacter(TextCursor cursor) {
     expect(cursor.moveNext(), isTrue);
     return cursor.current;
   }
 
-  @internal static void ValidateBeginningOfString(TextCursor cursor) {
+  @isInternal static void ValidateBeginningOfString(TextCursor cursor) {
     ValidateCurrentCharacter(cursor, -1, TextCursor.nul);
   }
 
-  @internal static void ValidateCurrentCharacter(TextCursor cursor, int expectedCurrentIndex, String /*char*/ expectedCurrentCharacter) {
+  @isInternal static void ValidateCurrentCharacter(TextCursor cursor, int expectedCurrentIndex, String /*char*/ expectedCurrentCharacter) {
     expect(cursor.current, expectedCurrentCharacter);
     expect(cursor.index, expectedCurrentIndex);
   }
 
-  @internal static void ValidateEndOfString(TextCursor cursor) {
+  @isInternal static void ValidateEndOfString(TextCursor cursor) {
     ValidateCurrentCharacter(cursor, cursor.length, TextCursor.nul);
   }
 
@@ -91,7 +91,7 @@ abstract class TextCursorTestBase {
     ValidateContents(cursor, value, -1);
   }*/
 
-  @internal static void ValidateContents(TextCursor cursor, String value, [int length = -1]) {
+  @isInternal static void ValidateContents(TextCursor cursor, String value, [int length = -1]) {
     if (length < 0) {
       length = value.length;
     }
@@ -99,6 +99,6 @@ abstract class TextCursorTestBase {
     expect(length, cursor.length, reason: 'Cursor Length mismatch');
   }
 
-  @internal TextCursor MakeCursor(String value);
+  @isInternal TextCursor MakeCursor(String value);
 }
 

--- a/test/text/value_cursor_test.dart
+++ b/test/text/value_cursor_test.dart
@@ -21,7 +21,7 @@ class ValueCursorTest extends TextCursorTestBase {
   ValidateCurrentCharacter(TextCursor cursor, int expectedCurrentIndex, String /*char*/ expectedCurrentCharacter) =>
       TextCursorTestBase.ValidateCurrentCharacter(cursor, expectedCurrentIndex, expectedCurrentCharacter);
 
-  @internal
+  @isInternal
   @override
   TextCursor MakeCursor(String value) {
     return ValueCursor(value);

--- a/test/text/zoneddatetime_pattern_test.dart
+++ b/test/text/zoneddatetime_pattern_test.dart
@@ -70,7 +70,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
   @private static final ZonedDateTime MsdnStandardExample = TestLocalDateTimes.MsdnStandardExample.inUtc();
   @private static final ZonedDateTime MsdnStandardExampleNoMillis = TestLocalDateTimes.MsdnStandardExampleNoMillis.inUtc();
 
-  @internal final List<Data> InvalidPatternData = [
+  @isInternal final List<Data> InvalidPatternData = [
     Data()
       ..pattern = ''
       ..message = TextErrorMessages.formatStringEmpty,
@@ -129,7 +129,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       ..parameters.addAll(['l']),
   ];
 
-  @internal List<Data> ParseFailureData = [
+  @isInternal List<Data> ParseFailureData = [
     // Skipped value
     Data()
       ..pattern = 'yyyy-MM-dd HH:mm z'
@@ -220,7 +220,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       ..message = TextErrorMessages.noMatchingZoneId
   ];
 
-  @internal List<Data> ParseOnlyData = [
+  @isInternal List<Data> ParseOnlyData = [
     // Template value time zone is from a different provider, but it's not part of the pattern.
     Data.b(2013, 1, 13, 16, 2, France)
       ..pattern = 'yyyy-MM-dd HH:mm'
@@ -295,7 +295,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       ..text = '2013-01-13 15:44 UTC+01:00:00',
   ];
 
-  @internal List<Data> FormatOnlyData = [
+  @isInternal List<Data> FormatOnlyData = [
     Data.c(2011, 10, 19, 16, 05, 20)
       ..pattern = 'ddd yyyy'
       ..text = 'Wed 2011',
@@ -356,7 +356,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       ..Resolver = null,
   ];
 
-  @internal List<Data> FormatAndParseData = [
+  @isInternal List<Data> FormatAndParseData = [
 
     // Zone ID at the end
     Data.b(2013, 01, 13, 15, 44, TestZone1)
@@ -697,9 +697,9 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       ..text = '15 June 2009 (A.D.) 1:45:30.09 PM',
   ];
 
-  @internal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get ParseData => [ParseOnlyData, FormatAndParseData].expand((x) => x);
 
-  @internal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
+  @isInternal Iterable<Data> get FormatData => [FormatOnlyData, FormatAndParseData].expand((x) => x);
 
   @Test()
   void WithTemplateValue() {
@@ -783,8 +783,8 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
 // Default to the start of the year 2000 UTC
 /*protected*/ @override ZonedDateTime get defaultTemplate => ZonedDateTimePatterns.defaultTemplateValue;
 
-  @internal ZoneLocalMappingResolver Resolver;
-  @internal DateTimeZoneProvider ZoneProvider;
+  @isInternal ZoneLocalMappingResolver Resolver;
+  @isInternal DateTimeZoneProvider ZoneProvider;
 
   /// Initializes a new instance of the [Data] class.
   ///
@@ -825,7 +825,7 @@ class ZonedDateTimePatternTest extends PatternTestBase<ZonedDateTime> {
       second,
       ms: millis).inZoneStrictly(zone));
 
-  @internal
+  @isInternal
   @override
   IPattern<ZonedDateTime> CreatePattern() =>
       ZonedDateTimePattern.createWithCulture(super.pattern, super.culture, Resolver, ZoneProvider, template);

--- a/test/timezones/timezone_info_replacer.dart
+++ b/test/timezones/timezone_info_replacer.dart
@@ -18,7 +18,7 @@ Future main() async {
   await runTests();
 }
 
-@internal class TimeZoneInfoReplacer extends TimeZoneInfo // TimeZoneInfoInterceptor // .ITimeZoneInfoShim
+@isInternal class TimeZoneInfoReplacer extends TimeZoneInfo // TimeZoneInfoInterceptor // .ITimeZoneInfoShim
 {
   /*
 final TimeZoneInfoInterceptor.ITimeZoneInfoShim originalShim;

--- a/tzdb_compiler/tzdb/utility/binary_writer.dart
+++ b/tzdb_compiler/tzdb/utility/binary_writer.dart
@@ -80,7 +80,7 @@ class MemoryStream implements io.IOSink {
   }
 }
 
-@internal
+@isInternal
 class BinaryWriter {
   static const _bufferSize = 1024 * 16;
   static const _bufferFlush = 1024 * 4;

--- a/tzdb_compiler/tzdb/utility/datetimezone_writer.dart
+++ b/tzdb_compiler/tzdb/utility/datetimezone_writer.dart
@@ -10,7 +10,7 @@ import 'package:time_machine/src/timezones/time_machine_timezones.dart';
 
 import 'binary_writer.dart';
 
-@internal
+@isInternal
 class DateTimeZoneWriter implements BinaryWriter, IDateTimeZoneWriter {
   BinaryWriter _writer;
   final List<String> _stringPool;


### PR DESCRIPTION
This fixes #44 by avoiding a name collision with the `meta` package.

It's the simplest solution I could find for now - we should consider removing this custom annotation eventually and just using the one provided by `meta`.