### PR TITLE
DayOfWeek.parse should be static and not a method on a instance

### DIFF
--- a/lib/src/dayofweek.dart
+++ b/lib/src/dayofweek.dart
@@ -55,7 +55,7 @@ class DayOfWeek {
   @override
   String toString() => _stringRepresentations[_value];
 
-  DayOfWeek? parse(String text) {
+  static DayOfWeek? parse(String text) {
     var token = text.trim().toLowerCase();
     for (int i = 0; i < _stringRepresentations.length; i++) {
       if (stringOrdinalIgnoreCaseEquals(_stringRepresentations[i], token)) return _isoConstants[i];


### PR DESCRIPTION
For me the parsing should be a static method, because it doesn't make any sense for me to use a instance of a DayOfWeek, if i want to create it by parsing something. 

Otherwise it's always something like this: `DayOfWeek.none.parse(serialized);` which wouldn't be a deal-breaker, but not super clean as well.