### PR TITLE
upgrade to null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 # Verify flutter_test dependency compatibility first before updating any constraints
 # https://github.com/flutter/flutter/blob/master/packages/flutter_test/pubspec.yaml
 dependencies:
-  meta: "^1.3.0"
+  meta: ^1.7.0
 #  quiver_hashcode: "^1.0.0"
 #  collection: "^1.14.10"
   collection: "^1.15.0"
@@ -20,15 +20,15 @@ dependencies:
 #    sdk: flutter
 
 dev_dependencies:
-  test: "^1.16.8"
-  matcher: "^0.12.10"
-  pedantic: "^1.11.0"
-  args: ^2.0.0
-  archive: ^3.1.2
+  test: ^1.17.12
+  matcher: ^0.12.11
+  pedantic: ^1.11.1
+  args: ^2.3.0
+  archive: ^3.2.0
   # used for the TzdbCompiler
-  http: "^0.13.1"
-  path: "^1.8.0"
-  xml: "^5.0.2"
+  http: ^0.13.3
+  path: ^1.8.1
+  xml: ^5.1.2
 
 # Flutter Testing
 #  test: "^0.12.3"


### PR DESCRIPTION
Ran through the Migration procedure at https://dart.dev/null-safety/migration-guide

Since all the dependencies were null-safe, no code changes needed to be applied.